### PR TITLE
feat: #11 Order エンティティ（集約ルート）実装

### DIFF
--- a/src/domain/entities/Order.ts
+++ b/src/domain/entities/Order.ts
@@ -1,0 +1,133 @@
+import { Buyer } from '../valueObjects/Buyer';
+import { OrderId } from '../valueObjects/OrderId';
+import { OrderStatus } from '../valueObjects/OrderStatus';
+import { Platform } from '../valueObjects/Platform';
+import { Product } from '../valueObjects/Product';
+import { ShippingMethod } from '../valueObjects/ShippingMethod';
+import { TrackingNumber } from '../valueObjects/TrackingNumber';
+
+export interface OrderRegistered {
+  readonly type: 'OrderRegistered';
+  readonly orderId: string;
+  readonly occurredAt: Date;
+}
+
+export interface OrderShipped {
+  readonly type: 'OrderShipped';
+  readonly orderId: string;
+  readonly shippingMethod: string;
+  readonly trackingNumber?: string;
+  readonly occurredAt: Date;
+}
+
+export type OrderDomainEvent = OrderRegistered | OrderShipped;
+
+interface NewOrderParams {
+  orderId: OrderId;
+  platform: Platform;
+  buyer: Buyer;
+  product: Product;
+  orderedAt?: Date;
+}
+
+interface ReconstitutedOrderParams {
+  orderId: OrderId;
+  platform: Platform;
+  buyer: Buyer;
+  product: Product;
+  status: OrderStatus;
+  orderedAt: Date;
+  shippedAt?: Date;
+  shippingMethod?: ShippingMethod;
+  trackingNumber?: TrackingNumber;
+}
+
+/**
+ * Order — 注文集約ルート
+ */
+export class Order {
+  readonly orderId: OrderId;
+  readonly platform: Platform;
+  readonly buyer: Buyer;
+  readonly product: Product;
+  status: OrderStatus;
+  readonly orderedAt: Date;
+  shippedAt?: Date;
+  shippingMethod?: ShippingMethod;
+  trackingNumber?: TrackingNumber;
+
+  private domainEvents: OrderDomainEvent[] = [];
+
+  private constructor(params: ReconstitutedOrderParams, options?: { suppressEvent?: boolean }) {
+    this.orderId = params.orderId;
+    this.platform = params.platform;
+    this.buyer = params.buyer;
+    this.product = params.product;
+    this.status = params.status;
+    this.orderedAt = params.orderedAt;
+    this.shippedAt = params.shippedAt;
+    this.shippingMethod = params.shippingMethod;
+    this.trackingNumber = params.trackingNumber;
+
+    if (!options?.suppressEvent) {
+      this.domainEvents.push({
+        type: 'OrderRegistered',
+        orderId: this.orderId.toString(),
+        occurredAt: new Date(),
+      });
+    }
+  }
+
+  static create(params: NewOrderParams): Order {
+    return new Order({
+      orderId: params.orderId,
+      platform: params.platform,
+      buyer: params.buyer,
+      product: params.product,
+      status: OrderStatus.Pending,
+      orderedAt: params.orderedAt ?? new Date(),
+    });
+  }
+
+  static reconstitute(params: ReconstitutedOrderParams): Order {
+    return new Order(params, { suppressEvent: true });
+  }
+
+  /**
+   * DR-ORD-003, DR-ORD-004, DR-ORD-005
+   */
+  markAsShipped(method: ShippingMethod, trackingNumber?: TrackingNumber): void {
+    if (!this.status.isPending()) {
+      throw new Error('発送済みの注文は変更できません');
+    }
+
+    this.status = OrderStatus.Shipped;
+    this.shippedAt = new Date();
+    this.shippingMethod = method;
+    this.trackingNumber = trackingNumber;
+
+    this.domainEvents.push({
+      type: 'OrderShipped',
+      orderId: this.orderId.toString(),
+      shippingMethod: method.toString(),
+      trackingNumber: trackingNumber?.toString(),
+      occurredAt: this.shippedAt,
+    });
+  }
+
+  isOverdue(): boolean {
+    return this.status.isPending() && this.getDaysSinceOrder() >= 3;
+  }
+
+  getDaysSinceOrder(): number {
+    const millisecondsPerDay = 24 * 60 * 60 * 1000;
+    const elapsed = Date.now() - this.orderedAt.getTime();
+    return Math.floor(elapsed / millisecondsPerDay);
+  }
+
+  pullDomainEvents(): OrderDomainEvent[] {
+    const events = [...this.domainEvents];
+    this.domainEvents = [];
+    return events;
+  }
+}

--- a/src/domain/entities/__tests__/Order.test.ts
+++ b/src/domain/entities/__tests__/Order.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Order } from '../Order';
+import { Address } from '../../valueObjects/Address';
+import { Buyer } from '../../valueObjects/Buyer';
+import { BuyerName } from '../../valueObjects/BuyerName';
+import { OrderId } from '../../valueObjects/OrderId';
+import { OrderStatus } from '../../valueObjects/OrderStatus';
+import { Platform } from '../../valueObjects/Platform';
+import { PostalCode } from '../../valueObjects/PostalCode';
+import { Prefecture } from '../../valueObjects/Prefecture';
+import { Product } from '../../valueObjects/Product';
+import { ShippingMethod } from '../../valueObjects/ShippingMethod';
+import { TrackingNumber } from '../../valueObjects/TrackingNumber';
+
+describe('Order', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const createBuyer = (): Buyer =>
+    new Buyer({
+      name: new BuyerName('田中太郎'),
+      address: new Address({
+        postalCode: new PostalCode('1000001'),
+        prefecture: new Prefecture('東京都'),
+        city: '千代田区',
+        street: '千代田1-1',
+      }),
+    });
+
+  const createProduct = (): Product =>
+    new Product({
+      name: 'ハンドメイド作品',
+      price: 3000,
+    });
+
+  const createOrder = (orderedAt?: Date): Order =>
+    Order.create({
+      orderId: new OrderId('ORD-001'),
+      platform: Platform.Minne,
+      buyer: createBuyer(),
+      product: createProduct(),
+      orderedAt,
+    });
+
+  it('新規作成時にpending状態でOrderRegisteredイベントが発行される', () => {
+    const order = createOrder();
+
+    expect(order.status.equals(OrderStatus.Pending)).toBe(true);
+    expect(order.shippedAt).toBeUndefined();
+    expect(order.shippingMethod).toBeUndefined();
+    expect(order.trackingNumber).toBeUndefined();
+
+    const events = order.pullDomainEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe('OrderRegistered');
+  });
+
+  it('reconstitute時はOrderRegisteredイベントを発行しない', () => {
+    const order = Order.reconstitute({
+      orderId: new OrderId('ORD-RECON-001'),
+      platform: Platform.Creema,
+      buyer: createBuyer(),
+      product: createProduct(),
+      status: OrderStatus.Pending,
+      orderedAt: new Date('2026-02-10T00:00:00Z'),
+    });
+
+    expect(order.pullDomainEvents()).toEqual([]);
+  });
+
+  it('markAsShippedでpendingからshippedに遷移し、発送情報と日時を記録する', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-17T00:00:00Z'));
+
+    const order = createOrder(new Date('2026-02-15T00:00:00Z'));
+    order.pullDomainEvents();
+
+    const trackingNumber = new TrackingNumber('CP123456789JP');
+    order.markAsShipped(ShippingMethod.ClickPost, trackingNumber);
+
+    expect(order.status.equals(OrderStatus.Shipped)).toBe(true);
+    expect(order.shippingMethod?.equals(ShippingMethod.ClickPost)).toBe(true);
+    expect(order.trackingNumber?.equals(trackingNumber)).toBe(true);
+    expect(order.shippedAt?.toISOString()).toBe('2026-02-17T00:00:00.000Z');
+  });
+
+  it('発送済み注文に対してmarkAsShippedを再実行するとエラーになる', () => {
+    const order = createOrder();
+    order.markAsShipped(ShippingMethod.YamatoCompact);
+
+    expect(() => order.markAsShipped(ShippingMethod.ClickPost)).toThrow(
+      '発送済みの注文は変更できません',
+    );
+  });
+
+  it('markAsShipped時にOrderShippedイベントを発行する', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-17T12:00:00Z'));
+
+    const order = createOrder();
+    order.pullDomainEvents();
+
+    order.markAsShipped(ShippingMethod.YamatoCompact);
+    const events = order.pullDomainEvents();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'OrderShipped',
+      orderId: 'ORD-001',
+      shippingMethod: 'yamato_compact',
+      trackingNumber: undefined,
+      occurredAt: new Date('2026-02-17T12:00:00Z'),
+    });
+  });
+
+  it('getDaysSinceOrderは注文日からの経過日数を返す', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-17T00:00:00Z'));
+
+    const order = createOrder(new Date('2026-02-14T00:00:00Z'));
+    expect(order.getDaysSinceOrder()).toBe(3);
+  });
+
+  it('isOverdueは3日以上経過したpending注文でtrueを返す（DR-ORD-006）', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-17T00:00:00Z'));
+
+    const order = createOrder(new Date('2026-02-14T00:00:00Z'));
+    expect(order.isOverdue()).toBe(true);
+  });
+
+  it('isOverdueは3日未満またはshipped注文ではfalseを返す', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-17T00:00:00Z'));
+
+    const recentOrder = createOrder(new Date('2026-02-16T00:00:00Z'));
+    expect(recentOrder.isOverdue()).toBe(false);
+
+    const shippedOrder = createOrder(new Date('2026-02-10T00:00:00Z'));
+    shippedOrder.markAsShipped(ShippingMethod.ClickPost);
+    expect(shippedOrder.isOverdue()).toBe(false);
+  });
+
+  it('pullDomainEventsはイベントを返し、その後キューをクリアする', () => {
+    const order = createOrder();
+
+    const firstPull = order.pullDomainEvents();
+    const secondPull = order.pullDomainEvents();
+
+    expect(firstPull).toHaveLength(1);
+    expect(secondPull).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #11 の内容に基づき、Order 集約ルートを実装しました。

## 変更内容
- `Order` エンティティを追加
  - `orderId, platform, buyer, product, status, orderedAt, shippedAt, shippingMethod, trackingNumber`
- `markAsShipped(method, trackingNumber?)` 実装（DR-ORD-003/004/005）
- `isOverdue(): boolean` 実装（DR-ORD-006）
- `getDaysSinceOrder(): number` 実装
- ドメインイベント発行を追加
  - `OrderRegistered`
  - `OrderShipped`
- ユニットテスト追加（`src/domain/entities/__tests__/Order.test.ts`）

## 受け入れ条件への対応
- [x] pending → shipped の一方向遷移のみ許可
- [x] 発送済みの注文に対する変更はエラー
- [x] 発送完了時に日時が記録される
- [x] 全メソッドにユニットテストがある

## 確認
- `npm run test`
- `npm run lint`
- `npm run format:check`
- `npx tsc --noEmit`

Closes #11
