### PR TITLE
feat: ShippingLabel 集約ルートと派生ラベルを実装 (#12)

### DIFF
--- a/src/domain/entities/ClickPostLabel.ts
+++ b/src/domain/entities/ClickPostLabel.ts
@@ -1,0 +1,37 @@
+import { ShippingLabel } from '@/domain/entities/ShippingLabel';
+import { LabelId } from '@/domain/valueObjects/LabelId';
+import { OrderId } from '@/domain/valueObjects/OrderId';
+import { TrackingNumber } from '@/domain/valueObjects/TrackingNumber';
+
+type ClickPostLabelParams = {
+  labelId: LabelId;
+  orderId: OrderId;
+  pdfData: string;
+  trackingNumber: TrackingNumber;
+  issuedAt?: Date;
+};
+
+/**
+ * ClickPostLabel — クリックポスト伝票
+ */
+export class ClickPostLabel extends ShippingLabel {
+  readonly pdfData: string;
+  readonly trackingNumber: TrackingNumber;
+
+  constructor(params: ClickPostLabelParams) {
+    if (!params.pdfData || params.pdfData.trim().length === 0) {
+      throw new Error('PDFデータは空にできません');
+    }
+
+    super({
+      labelId: params.labelId,
+      orderId: params.orderId,
+      type: 'click_post',
+      status: 'issued',
+      issuedAt: params.issuedAt,
+    });
+
+    this.pdfData = params.pdfData;
+    this.trackingNumber = params.trackingNumber;
+  }
+}

--- a/src/domain/entities/ShippingLabel.ts
+++ b/src/domain/entities/ShippingLabel.ts
@@ -1,0 +1,45 @@
+import { LabelId } from '@/domain/valueObjects/LabelId';
+import { OrderId } from '@/domain/valueObjects/OrderId';
+
+export const ShippingLabelTypeValues = ['click_post', 'yamato_compact'] as const;
+export type ShippingLabelTypeValue = (typeof ShippingLabelTypeValues)[number];
+
+export const LabelStatusValues = ['issued'] as const;
+export type LabelStatusValue = (typeof LabelStatusValues)[number];
+
+type ShippingLabelParams = {
+  labelId: LabelId;
+  orderId: OrderId;
+  type: ShippingLabelTypeValue;
+  status?: LabelStatusValue;
+  issuedAt?: Date;
+  expiresAt?: Date | null;
+};
+
+/**
+ * ShippingLabel — 伝票集約ルート
+ */
+export class ShippingLabel {
+  readonly labelId: LabelId;
+  readonly orderId: OrderId;
+  readonly type: ShippingLabelTypeValue;
+  readonly status: LabelStatusValue;
+  readonly issuedAt: Date;
+  readonly expiresAt?: Date;
+
+  constructor(params: ShippingLabelParams) {
+    this.labelId = params.labelId;
+    this.orderId = params.orderId;
+    this.type = params.type;
+    this.status = params.status ?? 'issued';
+    this.issuedAt = new Date((params.issuedAt ?? new Date()).getTime());
+    this.expiresAt = params.expiresAt ? new Date(params.expiresAt.getTime()) : undefined;
+  }
+
+  isExpired(referenceDate: Date = new Date()): boolean {
+    if (!this.expiresAt) {
+      return false;
+    }
+    return this.expiresAt.getTime() < referenceDate.getTime();
+  }
+}

--- a/src/domain/entities/YamatoCompactLabel.ts
+++ b/src/domain/entities/YamatoCompactLabel.ts
@@ -1,0 +1,47 @@
+import { ShippingLabel } from '@/domain/entities/ShippingLabel';
+import { LabelId } from '@/domain/valueObjects/LabelId';
+import { OrderId } from '@/domain/valueObjects/OrderId';
+
+type YamatoCompactLabelParams = {
+  labelId: LabelId;
+  orderId: OrderId;
+  qrCode: string;
+  waybillNumber: string;
+  issuedAt?: Date;
+};
+
+/**
+ * YamatoCompactLabel — 宅急便コンパクト伝票
+ * DR-LBL-001: 発行から14日間有効
+ */
+export class YamatoCompactLabel extends ShippingLabel {
+  static readonly EXPIRY_DAYS = 14;
+
+  readonly qrCode: string;
+  readonly waybillNumber: string;
+
+  constructor(params: YamatoCompactLabelParams) {
+    if (!params.qrCode || params.qrCode.trim().length === 0) {
+      throw new Error('QRコードは空にできません');
+    }
+    if (!params.waybillNumber || params.waybillNumber.trim().length === 0) {
+      throw new Error('送り状番号は空にできません');
+    }
+
+    const issuedAt = params.issuedAt ?? new Date();
+    const expiresAt = new Date(issuedAt.getTime());
+    expiresAt.setDate(expiresAt.getDate() + YamatoCompactLabel.EXPIRY_DAYS);
+
+    super({
+      labelId: params.labelId,
+      orderId: params.orderId,
+      type: 'yamato_compact',
+      status: 'issued',
+      issuedAt,
+      expiresAt,
+    });
+
+    this.qrCode = params.qrCode;
+    this.waybillNumber = params.waybillNumber;
+  }
+}

--- a/src/domain/entities/__tests__/ClickPostLabel.test.ts
+++ b/src/domain/entities/__tests__/ClickPostLabel.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { ClickPostLabel } from '@/domain/entities/ClickPostLabel';
+import { LabelId } from '@/domain/valueObjects/LabelId';
+import { OrderId } from '@/domain/valueObjects/OrderId';
+import { TrackingNumber } from '@/domain/valueObjects/TrackingNumber';
+
+describe('ClickPostLabel', () => {
+  it('クリックポスト伝票を作成できる', () => {
+    const label = new ClickPostLabel({
+      labelId: new LabelId('LBL-CP-001'),
+      orderId: new OrderId('ORD-001'),
+      pdfData: 'base64-pdf-data',
+      trackingNumber: new TrackingNumber('123456789012'),
+      issuedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    expect(label.type).toBe('click_post');
+    expect(label.status).toBe('issued');
+    expect(label.pdfData).toBe('base64-pdf-data');
+    expect(label.trackingNumber.value).toBe('123456789012');
+    expect(label.isExpired(new Date('2030-01-01T00:00:00.000Z'))).toBe(false);
+  });
+
+  it('PDFデータが空ならエラーになる', () => {
+    expect(
+      () =>
+        new ClickPostLabel({
+          labelId: new LabelId('LBL-CP-001'),
+          orderId: new OrderId('ORD-001'),
+          pdfData: '   ',
+          trackingNumber: new TrackingNumber('123456789012'),
+        }),
+    ).toThrow('PDFデータは空にできません');
+  });
+});

--- a/src/domain/entities/__tests__/ShippingLabel.test.ts
+++ b/src/domain/entities/__tests__/ShippingLabel.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { ShippingLabel } from '@/domain/entities/ShippingLabel';
+import { LabelId } from '@/domain/valueObjects/LabelId';
+import { OrderId } from '@/domain/valueObjects/OrderId';
+
+describe('ShippingLabel', () => {
+  it('Order と ID参照で紐づく', () => {
+    const orderId = new OrderId('ORD-001');
+    const label = new ShippingLabel({
+      labelId: new LabelId('LBL-001'),
+      orderId,
+      type: 'click_post',
+    });
+
+    expect(label.orderId).toBe(orderId);
+    expect(label.orderId.value).toBe('ORD-001');
+  });
+
+  it('expiresAt が未設定なら isExpired は false', () => {
+    const label = new ShippingLabel({
+      labelId: new LabelId('LBL-001'),
+      orderId: new OrderId('ORD-001'),
+      type: 'click_post',
+    });
+
+    expect(label.isExpired()).toBe(false);
+  });
+
+  it('expiresAt を過ぎていれば isExpired は true', () => {
+    const label = new ShippingLabel({
+      labelId: new LabelId('LBL-001'),
+      orderId: new OrderId('ORD-001'),
+      type: 'yamato_compact',
+      issuedAt: new Date('2026-01-01T00:00:00.000Z'),
+      expiresAt: new Date('2026-01-15T00:00:00.000Z'),
+    });
+
+    expect(label.isExpired(new Date('2026-01-15T00:00:00.001Z'))).toBe(true);
+  });
+
+  it('expiresAt 以前なら isExpired は false', () => {
+    const label = new ShippingLabel({
+      labelId: new LabelId('LBL-001'),
+      orderId: new OrderId('ORD-001'),
+      type: 'yamato_compact',
+      issuedAt: new Date('2026-01-01T00:00:00.000Z'),
+      expiresAt: new Date('2026-01-15T00:00:00.000Z'),
+    });
+
+    expect(label.isExpired(new Date('2026-01-14T23:59:59.999Z'))).toBe(false);
+  });
+});

--- a/src/domain/entities/__tests__/YamatoCompactLabel.test.ts
+++ b/src/domain/entities/__tests__/YamatoCompactLabel.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { YamatoCompactLabel } from '@/domain/entities/YamatoCompactLabel';
+import { LabelId } from '@/domain/valueObjects/LabelId';
+import { OrderId } from '@/domain/valueObjects/OrderId';
+
+describe('YamatoCompactLabel', () => {
+  it('宅急便コンパクト伝票を作成できる', () => {
+    const issuedAt = new Date('2026-01-01T00:00:00.000Z');
+    const label = new YamatoCompactLabel({
+      labelId: new LabelId('LBL-YM-001'),
+      orderId: new OrderId('ORD-001'),
+      qrCode: 'qr-code-data',
+      waybillNumber: '1234-5678-9012',
+      issuedAt,
+    });
+
+    expect(label.type).toBe('yamato_compact');
+    expect(label.status).toBe('issued');
+    expect(label.qrCode).toBe('qr-code-data');
+    expect(label.waybillNumber).toBe('1234-5678-9012');
+    expect(label.expiresAt?.toISOString()).toBe('2026-01-15T00:00:00.000Z');
+  });
+
+  it('発行から13日後は有効（DR-LBL-001）', () => {
+    const label = new YamatoCompactLabel({
+      labelId: new LabelId('LBL-YM-001'),
+      orderId: new OrderId('ORD-001'),
+      qrCode: 'qr-code-data',
+      waybillNumber: '1234-5678-9012',
+      issuedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    expect(label.isExpired(new Date('2026-01-14T23:59:59.999Z'))).toBe(false);
+  });
+
+  it('発行から14日を過ぎると期限切れ（DR-LBL-001）', () => {
+    const label = new YamatoCompactLabel({
+      labelId: new LabelId('LBL-YM-001'),
+      orderId: new OrderId('ORD-001'),
+      qrCode: 'qr-code-data',
+      waybillNumber: '1234-5678-9012',
+      issuedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    expect(label.isExpired(new Date('2026-01-15T00:00:00.001Z'))).toBe(true);
+  });
+
+  it('QRコードが空ならエラーになる', () => {
+    expect(
+      () =>
+        new YamatoCompactLabel({
+          labelId: new LabelId('LBL-YM-001'),
+          orderId: new OrderId('ORD-001'),
+          qrCode: ' ',
+          waybillNumber: '1234-5678-9012',
+        }),
+    ).toThrow('QRコードは空にできません');
+  });
+
+  it('送り状番号が空ならエラーになる', () => {
+    expect(
+      () =>
+        new YamatoCompactLabel({
+          labelId: new LabelId('LBL-YM-001'),
+          orderId: new OrderId('ORD-001'),
+          qrCode: 'qr-code-data',
+          waybillNumber: ' ',
+        }),
+    ).toThrow('送り状番号は空にできません');
+  });
+});


### PR DESCRIPTION
## 概要
- `ShippingLabel` 集約ルートを追加（`labelId`, `orderId`, `type`, `status`, `issuedAt`, `expiresAt`）
- `isExpired(referenceDate?)` を実装
- `ClickPostLabel`（`pdfData`, `trackingNumber`）を追加
- `YamatoCompactLabel`（`qrCode`, `waybillNumber`）を追加し、DR-LBL-001として14日有効を実装
- 各エンティティのユニットテストを追加

## 受け入れ条件対応
- [x] ShippingLabel が Order と ID参照で紐づく
- [x] YamatoCompactLabel の有効期限チェックが正しく動作する
- [x] 全メソッドにユニットテストがある

## 確認結果
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npx tsc --noEmit`

Closes #12
