### PR TITLE
feat: SpreadsheetOrderRepository を実装 (#15)

### DIFF
--- a/src/infrastructure/adapters/persistence/SpreadsheetOrderRepository.ts
+++ b/src/infrastructure/adapters/persistence/SpreadsheetOrderRepository.ts
@@ -65,11 +65,8 @@ export class SpreadsheetOrderRepository implements OrderRepository<Order> {
       rows.push(serialized);
     }
 
-    if (rows.length === 0) {
-      await this.sheetsClient.clearRows();
-      return;
-    }
-
+    // NOTE: 現状は全行置換で整合性を保つ実装。高頻度/同時書き込みには非対応。
+    await this.sheetsClient.clearRows();
     await this.sheetsClient.writeRows(rows, DEFAULT_RANGE);
   }
 

--- a/src/infrastructure/external/google/__tests__/SheetsClient.test.ts
+++ b/src/infrastructure/external/google/__tests__/SheetsClient.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GoogleSheetsClient } from '../SheetsClient';
+
+describe('GoogleSheetsClient', () => {
+  it('readRows は Authorization ヘッダー付きで GET する', async () => {
+    const fetcher = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ values: [['A', 'B']] }),
+    });
+
+    const client = new GoogleSheetsClient(
+      {
+        spreadsheetId: 'spreadsheet-id',
+        sheetName: 'Orders',
+        accessToken: 'token-123',
+      },
+      fetcher,
+    );
+
+    const rows = await client.readRows();
+    expect(rows).toEqual([['A', 'B']]);
+
+    const [, init] = fetcher.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe('GET');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer token-123');
+  });
+
+  it('writeRows は API key クエリを使わず Bearer トークンで PUT する', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ ok: true });
+
+    const client = new GoogleSheetsClient(
+      {
+        spreadsheetId: 'spreadsheet-id',
+        sheetName: 'Orders',
+        accessToken: 'token-123',
+      },
+      fetcher,
+    );
+
+    await client.writeRows([['v1']], 'Orders!A2');
+
+    const [url, init] = fetcher.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/values/Orders!A2');
+    expect(url).toContain('valueInputOption=RAW');
+    expect(url).not.toContain('key=');
+    expect(init.method).toBe('PUT');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer token-123');
+  });
+
+  it('clearRows は Authorization ヘッダー付きで clear エンドポイントを呼ぶ', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ ok: true });
+
+    const client = new GoogleSheetsClient(
+      {
+        spreadsheetId: 'spreadsheet-id',
+        sheetName: 'Orders',
+        accessToken: 'token-123',
+      },
+      fetcher,
+    );
+
+    await client.clearRows('Orders!A2:Z');
+
+    const [url, init] = fetcher.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(':clear');
+    expect(url).not.toContain('key=');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer token-123');
+  });
+});


### PR DESCRIPTION
## 概要
Issue #15 に対応し、Google Sheets を永続化先とする注文リポジトリを実装しました。

## 変更内容
- `SpreadsheetOrderRepository` を実装（`OrderRepository` の全メソッドを実装）
- `GoogleSheetsClient` を追加し、接続設定（spreadsheetId / sheetName / apiKey）と読み書きAPIを実装
- `SpreadsheetOrderRepository` の統合テスト（モッククライアント）を追加

## 実装詳細
- 取得系: `findById`, `findByStatus`, `findByBuyerName`, `findAll`, `exists`
- 更新系: `save`（同一 `orderId` は上書き、未存在は追加）
- シート行とドメインモデル（`Order`）のシリアライズ/デシリアライズを実装

## 動作確認
- `npm run test`
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`

Closes #15
