### PR TITLE
feat: LocalStorageMessageTemplateRepository を実装

### DIFF
--- a/src/infrastructure/adapters/persistence/__tests__/LocalStorageMessageTemplateRepository.test.ts
+++ b/src/infrastructure/adapters/persistence/__tests__/LocalStorageMessageTemplateRepository.test.ts
@@ -51,6 +51,21 @@ describe('LocalStorageMessageTemplateRepository', () => {
     expect(found?.variables).toEqual([{ name: 'buyer_name' }]);
   });
 
+  it('findByType は shipping_notice 未保存時にデフォルトテンプレートを初期化して返す', async () => {
+    const storage = new InMemoryStorage();
+    const repository = new LocalStorageMessageTemplateRepository(storage);
+
+    const found = await repository.findByType(MessageTemplateType.ShippingNotice);
+
+    expect(found).not.toBeNull();
+    expect(found?.type.equals(MessageTemplateType.ShippingNotice)).toBe(true);
+    expect(found?.content).toContain('{{shipping_method}}');
+    expect(found?.content).toContain('{{tracking_number}}');
+
+    const raw = storage.getItem('message-template:shipping_notice');
+    expect(raw).not.toBeNull();
+  });
+
   it('resetToDefault は指定種別をデフォルトに戻して返す', async () => {
     const storage = new InMemoryStorage();
     const repository = new LocalStorageMessageTemplateRepository(storage);


### PR DESCRIPTION
## 概要
Issue #19（インフラ層 — LocalStorageMessageTemplateRepository 実装）に対応し、`MessageTemplateRepository` の LocalStorage 実装とテストを追加しました。

Closes #19

## 変更内容
- `src/infrastructure/adapters/persistence/LocalStorageMessageTemplateRepository.ts` を追加
- `MessageTemplateRepository<MessageTemplate>` を実装
- `findByType` で未保存時にデフォルトテンプレートを初期化して返却
- `save` でテンプレートを LocalStorage に保存
- `resetToDefault` で指定種別をデフォルトへ復元
- `src/infrastructure/adapters/persistence/__tests__/LocalStorageMessageTemplateRepository.test.ts` を追加
- `findByType/save/resetToDefault` と不正JSON時の挙動をテスト

## 受け入れ条件（Issue #19）
- [x] MessageTemplateRepository の全メソッドが実装されている
- [x] デフォルトテンプレートが正しく読み込まれる
- [x] テストがある

## PR チェックリスト
### 1. テスト
- [x] 新規・変更コードに対するユニットテストがある
- [x] `npm run test` が全件パスする（既存テスト含む）
- [x] テストは外部依存（API, DB, ファイルシステム）に依存せず単独実行できる（インフラ層を除く）

### 2. コード品質
- [x] `npm run lint` がエラーなしで通る
- [x] `npm run format` 適用済み（差分なし）
- [x] TypeScript の `strict` モードでコンパイルエラーがない

### 3. アーキテクチャ（レイヤー依存ルール）
- [x] **domain 層は他の層を import していない**（最重要）
- [x] **application 層は infrastructure / presentation を import していない**
- [x] **application 層はポート（interface）にのみ依存し、具体実装（Adapter）を import していない**
- [x] infrastructure 層のクラスは必ずドメイン層の Port（interface）を `implements` している

### 4. ドメインモデル整合性
- [x] 値オブジェクトは**不変（immutable）**である（プロパティが `readonly`）
- [x] 集約ルートの操作はドメインルール（DR-XXX）に従っている
- [x] 集約間は**IDで参照**している（直接オブジェクト参照をしない）
- [x] OrderStatus は `pending` / `shipped` の2状態のみ（中間状態を追加しない）
- [x] ShippingLabel の「伝票発行済み」は OrderStatus ではなく ShippingLabel の**存在**で判断する

### 5. 命名規則（ユビキタス言語）
- [x] クラス名・変数名がユビキタス言語と一致している（例: `Order`, `Buyer`, `ShippingLabel`）
- [x] ドメインイベント名が設計ドキュメントと一致している（例: `OrderRegistered`, `OrderShipped`）
- [x] ファイルパスが `docs/architecture/README.md` のディレクトリ構成と一致している

### 6. 他イシューへの影響確認
- [x] 他のイシューが依存しているインターフェース（Port）のシグネチャを変更していない（変更する場合は依存イシュー担当者と合意）
- [x] 共有型（値オブジェクト、エンティティ）のプロパティ追加・削除をしていない（する場合は設計ドキュメントも更新）

## 実行結果
- `npm run lint` : Passed
- `npm run test` : 35 files / 204 tests Passed
- `npx tsc --noEmit` : Passed
