### PR TITLE
refactor: Route Handler のDIコンテナ導入 (#60)

### DIFF
--- a/src/app/api/buyers/search/route.ts
+++ b/src/app/api/buyers/search/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { SearchBuyersUseCase } from '@/application/usecases/SearchBuyersUseCase';
-import { SpreadsheetOrderRepository } from '@/infrastructure/adapters/persistence/SpreadsheetOrderRepository';
-import { GoogleSheetsClient } from '@/infrastructure/external/google/SheetsClient';
+import { createContainer } from '@/infrastructure/di/container';
 
 export async function GET(request: NextRequest) {
   const keyword = request.nextUrl.searchParams.get('name')?.trim() ?? '';
@@ -9,20 +7,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.json([]);
   }
 
-  const accessToken = process.env.GOOGLE_SHEETS_ACCESS_TOKEN ?? '';
-  const spreadsheetId = process.env.GOOGLE_SHEETS_SPREADSHEET_ID ?? '';
-  const sheetName = process.env.GOOGLE_SHEETS_SHEET_NAME ?? 'Orders';
-
-  const sheetsClient = new GoogleSheetsClient({
-    spreadsheetId,
-    sheetName,
-    accessToken,
-  });
-
-  const repository = new SpreadsheetOrderRepository(sheetsClient);
-  const useCase = new SearchBuyersUseCase(repository);
-
   try {
+    const container = createContainer();
+    const useCase = container.getSearchBuyersUseCase();
     const buyers = await useCase.execute({ buyerName: keyword });
     return NextResponse.json(buyers);
   } catch (err) {

--- a/src/app/api/orders/[orderId]/ship/route.ts
+++ b/src/app/api/orders/[orderId]/ship/route.ts
@@ -4,9 +4,7 @@ import {
   InvalidShipmentOperationError,
   OrderNotFoundError,
 } from '@/application/usecases/MarkOrderAsShippedErrors';
-import { MarkOrderAsShippedUseCase } from '@/application/usecases/MarkOrderAsShippedUseCase';
-import { SpreadsheetOrderRepository } from '@/infrastructure/adapters/persistence/SpreadsheetOrderRepository';
-import { GoogleSheetsClient } from '@/infrastructure/external/google/SheetsClient';
+import { createContainer } from '@/infrastructure/di/container';
 
 export async function POST(
   request: NextRequest,
@@ -41,20 +39,9 @@ export async function POST(
     return NextResponse.json({ error: '追跡番号は文字列で指定してください' }, { status: 400 });
   }
 
-  const accessToken = process.env.GOOGLE_SHEETS_ACCESS_TOKEN ?? '';
-  const spreadsheetId = process.env.GOOGLE_SHEETS_SPREADSHEET_ID ?? '';
-  const sheetName = process.env.GOOGLE_SHEETS_SHEET_NAME ?? 'Orders';
-
-  const sheetsClient = new GoogleSheetsClient({
-    spreadsheetId,
-    sheetName,
-    accessToken,
-  });
-
-  const repository = new SpreadsheetOrderRepository(sheetsClient);
-  const useCase = new MarkOrderAsShippedUseCase(repository);
-
   try {
+    const container = createContainer();
+    const useCase = container.getMarkOrderAsShippedUseCase();
     const result = await useCase.execute({
       orderId,
       shippingMethod: shippingMethod.trim(),

--- a/src/app/api/orders/pending/route.ts
+++ b/src/app/api/orders/pending/route.ts
@@ -1,25 +1,10 @@
 import { NextResponse } from 'next/server';
-import { ListPendingOrdersUseCase } from '@/application/usecases/ListPendingOrdersUseCase';
-import { OverdueOrderSpecification } from '@/domain/specifications/OverdueOrderSpecification';
-import { SpreadsheetOrderRepository } from '@/infrastructure/adapters/persistence/SpreadsheetOrderRepository';
-import { GoogleSheetsClient } from '@/infrastructure/external/google/SheetsClient';
+import { createContainer } from '@/infrastructure/di/container';
 
 export async function GET() {
-  const accessToken = process.env.GOOGLE_SHEETS_ACCESS_TOKEN ?? '';
-  const spreadsheetId = process.env.GOOGLE_SHEETS_SPREADSHEET_ID ?? '';
-  const sheetName = process.env.GOOGLE_SHEETS_SHEET_NAME ?? 'Orders';
-
-  const sheetsClient = new GoogleSheetsClient({
-    spreadsheetId,
-    sheetName,
-    accessToken,
-  });
-
-  const repository = new SpreadsheetOrderRepository(sheetsClient);
-  const overdueSpec = new OverdueOrderSpecification();
-  const useCase = new ListPendingOrdersUseCase(repository, overdueSpec);
-
   try {
+    const container = createContainer();
+    const useCase = container.getListPendingOrdersUseCase();
     const orders = await useCase.execute();
     return NextResponse.json(orders);
   } catch (err) {

--- a/src/infrastructure/di/container.ts
+++ b/src/infrastructure/di/container.ts
@@ -1,0 +1,47 @@
+import { ListPendingOrdersUseCase } from '@/application/usecases/ListPendingOrdersUseCase';
+import { MarkOrderAsShippedUseCase } from '@/application/usecases/MarkOrderAsShippedUseCase';
+import { SearchBuyersUseCase } from '@/application/usecases/SearchBuyersUseCase';
+import { OverdueOrderSpecification } from '@/domain/specifications/OverdueOrderSpecification';
+import { SpreadsheetOrderRepository } from '@/infrastructure/adapters/persistence/SpreadsheetOrderRepository';
+import { GoogleSheetsClient } from '@/infrastructure/external/google/SheetsClient';
+
+type Env = Readonly<Record<string, string | undefined>>;
+type SheetsEnvKey =
+  | 'GOOGLE_SHEETS_ACCESS_TOKEN'
+  | 'GOOGLE_SHEETS_SPREADSHEET_ID'
+  | 'GOOGLE_SHEETS_SHEET_NAME';
+
+function resolveRequiredEnv(name: SheetsEnvKey, env: Env): string {
+  const value = env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is not configured`);
+  }
+  return value;
+}
+
+function createOrderRepository(env: Env): SpreadsheetOrderRepository {
+  const sheetsClient = new GoogleSheetsClient({
+    spreadsheetId: resolveRequiredEnv('GOOGLE_SHEETS_SPREADSHEET_ID', env),
+    sheetName: env.GOOGLE_SHEETS_SHEET_NAME?.trim() || 'Orders',
+    accessToken: resolveRequiredEnv('GOOGLE_SHEETS_ACCESS_TOKEN', env),
+  });
+
+  return new SpreadsheetOrderRepository(sheetsClient);
+}
+
+export interface Container {
+  getListPendingOrdersUseCase(): ListPendingOrdersUseCase;
+  getMarkOrderAsShippedUseCase(): MarkOrderAsShippedUseCase;
+  getSearchBuyersUseCase(): SearchBuyersUseCase;
+}
+
+export function createContainer(env: Env = process.env): Container {
+  const orderRepository = createOrderRepository(env);
+  const overdueSpec = new OverdueOrderSpecification();
+
+  return {
+    getListPendingOrdersUseCase: () => new ListPendingOrdersUseCase(orderRepository, overdueSpec),
+    getMarkOrderAsShippedUseCase: () => new MarkOrderAsShippedUseCase(orderRepository),
+    getSearchBuyersUseCase: () => new SearchBuyersUseCase(orderRepository),
+  };
+}


### PR DESCRIPTION
## 概要
DIコンテナを導入し、Route Handler からインフラ層の具体実装を直接 `new` していた依存を解消しました。

### 変更内容
- `src/infrastructure/di/container.ts` を新規実装
  - `SpreadsheetOrderRepository` / `GoogleSheetsClient` の生成を集約
  - 環境変数の読み取りをコンテナに一元化
  - Route 用に以下 UseCase を取得するメソッドを提供
    - `getListPendingOrdersUseCase()`
    - `getMarkOrderAsShippedUseCase()`
    - `getSearchBuyersUseCase()`
- 既存 Route Handler をコンテナ経由に変更
  - `src/app/api/orders/pending/route.ts`
  - `src/app/api/orders/[orderId]/ship/route.ts`
  - `src/app/api/buyers/search/route.ts`

## 受け入れ条件
- [x] `src/infrastructure/di/container.ts` が実装されている
- [x] Route Handler がコンテナ経由で UseCase を取得している
- [x] Route Handler 内に `new SpreadsheetOrderRepository` 等の直接インスタンス化がない
- [x] 後続の Route Handler（Phase 3〜5）も同じパターンを踏襲する

## 確認
- [x] `npm run format`
- [x] `npm run lint`
- [x] `vitest` のAPIルート関連テスト
  - `src/app/api/orders/[orderId]/ship/__tests__/route.test.ts`
  - `src/app/api/buyers/search/__tests__/route.test.ts`
- [ ] `npx tsc --noEmit`
  - 既存の `@testing-library/react` 未導入に起因するエラーで失敗（今回変更範囲外）

Closes #60
