### PR TITLE
feat: Route Handler のエラーハンドリング改善 (#62)

### DIFF
--- a/src/app/api/buyers/search/route.ts
+++ b/src/app/api/buyers/search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SearchBuyersUseCase } from '@/application/usecases/SearchBuyersUseCase';
 import { SpreadsheetOrderRepository } from '@/infrastructure/adapters/persistence/SpreadsheetOrderRepository';
+import { normalizeHttpError, toApiErrorResponse } from '@/infrastructure/errors/HttpErrors';
 import { GoogleSheetsClient } from '@/infrastructure/external/google/SheetsClient';
 
 export async function GET(request: NextRequest) {
@@ -26,7 +27,10 @@ export async function GET(request: NextRequest) {
     const buyers = await useCase.execute({ buyerName: keyword });
     return NextResponse.json(buyers);
   } catch (err) {
-    console.error('購入者検索エラー:', err);
-    return NextResponse.json({ error: '購入者情報の検索に失敗しました' }, { status: 500 });
+    const normalizedError = normalizeHttpError(err, '購入者情報の検索に失敗しました');
+    console.error('購入者検索エラー:', normalizedError);
+    return NextResponse.json(toApiErrorResponse(normalizedError), {
+      status: normalizedError.statusCode,
+    });
   }
 }

--- a/src/app/api/orders/[orderId]/ship/route.ts
+++ b/src/app/api/orders/[orderId]/ship/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/application/usecases/MarkOrderAsShippedErrors';
 import { MarkOrderAsShippedUseCase } from '@/application/usecases/MarkOrderAsShippedUseCase';
 import { SpreadsheetOrderRepository } from '@/infrastructure/adapters/persistence/SpreadsheetOrderRepository';
+import { normalizeHttpError, toApiErrorResponse } from '@/infrastructure/errors/HttpErrors';
 import { GoogleSheetsClient } from '@/infrastructure/external/google/SheetsClient';
 
 export async function POST(
@@ -70,7 +71,10 @@ export async function POST(
       return NextResponse.json({ error: err.message }, { status: 400 });
     }
 
-    console.error('発送完了更新エラー:', err);
-    return NextResponse.json({ error: '発送完了の記録に失敗しました' }, { status: 500 });
+    const normalizedError = normalizeHttpError(err, '発送完了の記録に失敗しました');
+    console.error('発送完了更新エラー:', normalizedError);
+    return NextResponse.json(toApiErrorResponse(normalizedError), {
+      status: normalizedError.statusCode,
+    });
   }
 }

--- a/src/app/api/orders/pending/__tests__/route.test.ts
+++ b/src/app/api/orders/pending/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthenticationError, ExternalServiceError } from '@/infrastructure/errors/HttpErrors';
+
+const { executeMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+}));
+
+vi.mock('@/application/usecases/ListPendingOrdersUseCase', () => ({
+  ListPendingOrdersUseCase: class {
+    execute = executeMock;
+  },
+}));
+
+vi.mock('@/domain/specifications/OverdueOrderSpecification', () => ({
+  OverdueOrderSpecification: class {},
+}));
+
+vi.mock('@/infrastructure/adapters/persistence/SpreadsheetOrderRepository', () => ({
+  SpreadsheetOrderRepository: class {},
+}));
+
+vi.mock('@/infrastructure/external/google/SheetsClient', () => ({
+  GoogleSheetsClient: class {},
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/orders/pending', () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+  });
+
+  it('正常時は注文一覧を返す', async () => {
+    executeMock.mockResolvedValueOnce([{ orderId: 'ORD-001' }]);
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual([{ orderId: 'ORD-001' }]);
+  });
+
+  it('認証エラー時は 401 と統一フォーマットを返す', async () => {
+    executeMock.mockRejectedValueOnce(new AuthenticationError('認証に失敗しました'));
+
+    const response = await GET();
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: 'AUTHENTICATION_ERROR',
+        message: '認証に失敗しました',
+      },
+    });
+  });
+
+  it('外部サービスエラー時は 503 と統一フォーマットを返す', async () => {
+    executeMock.mockRejectedValueOnce(new ExternalServiceError('一時的に利用できません'));
+
+    const response = await GET();
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: 'EXTERNAL_SERVICE_ERROR',
+        message: '一時的に利用できません',
+      },
+    });
+  });
+
+  it('想定外エラー時は 500 と統一フォーマットを返す', async () => {
+    executeMock.mockRejectedValueOnce(new Error('unexpected'));
+
+    const response = await GET();
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: '注文の取得に失敗しました',
+      },
+    });
+  });
+});

--- a/src/app/api/orders/pending/route.ts
+++ b/src/app/api/orders/pending/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { ListPendingOrdersUseCase } from '@/application/usecases/ListPendingOrdersUseCase';
 import { OverdueOrderSpecification } from '@/domain/specifications/OverdueOrderSpecification';
 import { SpreadsheetOrderRepository } from '@/infrastructure/adapters/persistence/SpreadsheetOrderRepository';
+import { normalizeHttpError, toApiErrorResponse } from '@/infrastructure/errors/HttpErrors';
 import { GoogleSheetsClient } from '@/infrastructure/external/google/SheetsClient';
 
 export async function GET() {
@@ -23,7 +24,10 @@ export async function GET() {
     const orders = await useCase.execute();
     return NextResponse.json(orders);
   } catch (err) {
-    console.error('注文取得エラー:', err);
-    return NextResponse.json({ error: '注文の取得に失敗しました' }, { status: 500 });
+    const normalizedError = normalizeHttpError(err, '注文の取得に失敗しました');
+    console.error('注文取得エラー:', normalizedError);
+    return NextResponse.json(toApiErrorResponse(normalizedError), {
+      status: normalizedError.statusCode,
+    });
   }
 }

--- a/src/infrastructure/errors/HttpErrors.ts
+++ b/src/infrastructure/errors/HttpErrors.ts
@@ -1,0 +1,68 @@
+export type ErrorCode =
+  | 'AUTHENTICATION_ERROR'
+  | 'NOT_FOUND'
+  | 'EXTERNAL_SERVICE_ERROR'
+  | 'INTERNAL_SERVER_ERROR';
+
+export abstract class HttpError extends Error {
+  readonly code: ErrorCode;
+  readonly statusCode: number;
+
+  protected constructor(message: string, code: ErrorCode, statusCode: number) {
+    super(message);
+    this.name = new.target.name;
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+export class AuthenticationError extends HttpError {
+  constructor(message: string = '認証エラーが発生しました') {
+    super(message, 'AUTHENTICATION_ERROR', 401);
+  }
+}
+
+export class NotFoundError extends HttpError {
+  constructor(message: string = '対象が見つかりませんでした') {
+    super(message, 'NOT_FOUND', 404);
+  }
+}
+
+export class ExternalServiceError extends HttpError {
+  constructor(message: string = '外部サービスでエラーが発生しました') {
+    super(message, 'EXTERNAL_SERVICE_ERROR', 503);
+  }
+}
+
+export class InternalServerError extends HttpError {
+  constructor(message: string = '内部エラーが発生しました') {
+    super(message, 'INTERNAL_SERVER_ERROR', 500);
+  }
+}
+
+export interface ApiErrorResponse {
+  error: {
+    code: ErrorCode;
+    message: string;
+  };
+}
+
+export function toApiErrorResponse(error: HttpError): ApiErrorResponse {
+  return {
+    error: {
+      code: error.code,
+      message: error.message,
+    },
+  };
+}
+
+export function normalizeHttpError(
+  error: unknown,
+  fallbackMessage: string = '内部エラーが発生しました',
+): HttpError {
+  if (error instanceof HttpError) {
+    return error;
+  }
+
+  return new InternalServerError(fallbackMessage);
+}


### PR DESCRIPTION
## 概要
Route Handler のエラーハンドリングを改善し、エラー種別に応じた HTTP ステータスコード返却とレスポンス形式の統一を行いました。

## 変更内容
- `src/infrastructure/errors/HttpErrors.ts` を新規追加
  - `AuthenticationError`（401）
  - `NotFoundError`（404）
  - `ExternalServiceError`（503）
  - `InternalServerError`（500）
  - `normalizeHttpError` / `toApiErrorResponse` を実装
- `src/infrastructure/external/google/SheetsClient.ts`
  - Google Sheets API の HTTP ステータスに応じてカスタムエラーを送出
- `src/app/api/orders/pending/route.ts`
  - 例外を正規化し、HTTP ステータスを出し分け
  - エラーレスポンスを `{ error: { code, message } }` 形式に統一
- 後続Routeの踏襲
  - `src/app/api/buyers/search/route.ts`
  - `src/app/api/orders/[orderId]/ship/route.ts`
  - 上記2ルートの予期しない例外も共通フォーマットに統一

## テスト
- 追加
  - `src/app/api/orders/pending/__tests__/route.test.ts`
    - 401 / 503 / 500 の出し分けと統一レスポンスを検証
- 更新
  - `src/infrastructure/external/google/__tests__/SheetsClient.test.ts`
    - 401/403, 404, その他ステータスのエラー種別を検証
- 実行
  - [x] `npm run format`
  - [x] `npm run lint`
  - [x] `vitest`（変更対象の関連テスト）
    - `src/app/api/orders/pending/__tests__/route.test.ts`
    - `src/app/api/buyers/search/__tests__/route.test.ts`
    - `src/app/api/orders/[orderId]/ship/__tests__/route.test.ts`
    - `src/infrastructure/external/google/__tests__/SheetsClient.test.ts`
  - [ ] `npx tsc --noEmit`
    - 既存の `@testing-library/react` 未導入起因のエラーで失敗（今回変更範囲外）

Closes #62
