### PR TITLE
feat: #25-1 YamatoCompactAdapter + YamatoPudoPage 実装 (#55)

### DIFF
--- a/src/infrastructure/adapters/shipping/YamatoCompactAdapter.ts
+++ b/src/infrastructure/adapters/shipping/YamatoCompactAdapter.ts
@@ -9,12 +9,12 @@ import {
 } from '@/infrastructure/external/playwright/YamatoPudoPage';
 import { YamatoCompactGateway } from './YamatoCompactGateway';
 
-interface YamatoBrowserLike {
+export interface YamatoBrowserLike {
   newPage(): Promise<YamatoPlaywrightPageLike>;
   close(): Promise<void>;
 }
 
-interface YamatoBrowserFactory {
+export interface YamatoBrowserFactory {
   launch(): Promise<YamatoBrowserLike>;
 }
 

--- a/src/infrastructure/adapters/shipping/__tests__/YamatoCompactAdapter.test.ts
+++ b/src/infrastructure/adapters/shipping/__tests__/YamatoCompactAdapter.test.ts
@@ -72,6 +72,10 @@ describe('YamatoCompactAdapter', () => {
     expect(goto).toHaveBeenCalledWith('https://pudo.kuronekoyamato.co.jp/');
     expect(fill).toHaveBeenCalledWith('#member-id', 'yamato-id');
     expect(fill).toHaveBeenCalledWith('#password', 'secret');
+    expect(click).toHaveBeenCalledWith('text=ログイン');
+    expect(click).toHaveBeenCalledWith('text=宅急便コンパクト');
+    expect(click).toHaveBeenCalledWith('text=PUDO');
+    expect(click).toHaveBeenCalledWith('text=送り状を発行');
     expect(close).toHaveBeenCalledTimes(1);
   });
 

--- a/src/infrastructure/external/playwright/YamatoPudoPage.ts
+++ b/src/infrastructure/external/playwright/YamatoPudoPage.ts
@@ -8,6 +8,7 @@ export interface YamatoCredentials {
 }
 
 export interface YamatoPlaywrightPageLike {
+  // TODO: アダプタが増えたら Playwright の共通ページ型（BasePlaywrightPageLike）へ統合する
   goto(url: string): Promise<void>;
   fill(selector: string, value: string): Promise<void>;
   click(selector: string): Promise<void>;


### PR DESCRIPTION
## 概要
Issue #55（#25-1）として、infrastructure 層に宅急便コンパクト向けの Playwright アダプタを実装しました。

## 変更内容
- `src/infrastructure/adapters/shipping/YamatoCompactAdapter.ts`
  - `YamatoCompactGateway` を `implements`
  - Browser/Page を依存注入し、`YamatoPudoPage` へ委譲
  - QRコード・送り状番号から `YamatoCompactLabel` を生成
  - エラー時は文脈付きメッセージへ変換し `cause` を保持
  - `finally` で `browser.close()` を保証（close失敗は warn ログ）
- `src/infrastructure/external/playwright/YamatoPudoPage.ts`
  - Playwright Page Object パターンで PUDO サイト操作を実装
  - ログイン / 宅急便コンパクト選択 / PUDO選択 / 宛先入力 / QR・送り状番号取得
- `src/infrastructure/adapters/shipping/__tests__/YamatoCompactAdapter.test.ts`
  - 成功系: `YamatoCompactLabel` を返却できる
  - 失敗系: 文脈付きエラーを返却し `browser.close()` を呼ぶ
  - close失敗時も元エラーを優先し、警告ログが出る
  - Playwright 依存はモックで検証

## 受け入れ条件（#55）
- [x] YamatoCompactGateway インターフェースを implements している
- [x] QR コード取得ロジックが実装されている
- [x] エラー時のハンドリングが適切
- [x] テストがある（Playwright はモック）
- [ ] PR チェックリスト（#25 参照）を満たす

## 補足
- #25 の共通チェックリストは、指示どおり #56 のタイミングで対応します（本PRでは未チェック）。

## 実行コマンド
- `npm run test -- src/infrastructure/adapters/shipping/__tests__/YamatoCompactAdapter.test.ts`
- `npm run test`
- `npm run lint`
- `npm run format:check`
- `npx tsc --noEmit`

Closes #55
