### PR TITLE
feat: GOOGLE_SERVICE_ACCOUNT_BASE64 に対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Copy from .env.example and fill values for local development.
+
+# Google Sheets 認証（以下のいずれかを設定）
+
+# 方式1: サービスアカウント（推奨）
+# GCPコンソールからダウンロードした service-account.json をbase64化して設定
+# 例:
+# node -e "const fs=require('fs');process.stdout.write(Buffer.from(fs.readFileSync('service-account.json','utf8')).toString('base64'))"
+GOOGLE_SERVICE_ACCOUNT_BASE64=eyJ0eXBlIjoic2VydmljZV9hY2NvdW50IiwiY2xpZW50X2VtYWlsIjoieW91ci1zYUB5b3VyLXByb2plY3QuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJwcml2YXRlX2tleSI6Ii0tLS0tQkVHSU4gUFJJVkFURSBLRVktLS0tLVxuLi4uXG4tLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tXG4ifQ==
+
+# 方式2: OAuth2 リフレッシュトークン
+# GOOGLE_SHEETS_ACCESS_TOKEN=
+# GOOGLE_SHEETS_REFRESH_TOKEN=
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+
+# 方式3: 静的アクセストークン（テスト・一時利用向け）
+# GOOGLE_SHEETS_ACCESS_TOKEN=
+
+# Google Sheets 設定（必須）
+GOOGLE_SHEETS_SPREADSHEET_ID=your-spreadsheet-id
+GOOGLE_SHEETS_SHEET_NAME=Orders
+
+# Shipping providers
+CLICKPOST_EMAIL=
+CLICKPOST_PASSWORD=
+YAMATO_MEMBER_ID=
+YAMATO_PASSWORD=
+
+# Optional: playwright module name (default: playwright)
+PLAYWRIGHT_MODULE=playwright

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ npm test
 
 ```env
 # Google API
+# サービスアカウントJSONをbase64化した値
+GOOGLE_SERVICE_ACCOUNT_BASE64=
 # 初回アクセストークン（任意。未指定時は refresh token で自動取得）
 GOOGLE_SHEETS_ACCESS_TOKEN=
 # 必須
@@ -118,6 +120,12 @@ AMAZON_PASSWORD=
 # ヤマト運輸（クロネコメンバーズ）
 KURONEKO_EMAIL=
 KURONEKO_PASSWORD=
+```
+
+`GOOGLE_SERVICE_ACCOUNT_BASE64` は次のコマンドで作成できます。
+
+```bash
+node -e "const fs=require('fs');process.stdout.write(Buffer.from(fs.readFileSync('service-account.json','utf8')).toString('base64'))"
 ```
 
 ## ライセンス

--- a/src/infrastructure/di/__tests__/container.test.ts
+++ b/src/infrastructure/di/__tests__/container.test.ts
@@ -13,6 +13,9 @@ const VALID_SERVICE_ACCOUNT_JSON = JSON.stringify({
   client_email: 'test@test-project.iam.gserviceaccount.com',
   private_key: TEST_PRIVATE_KEY,
 });
+const VALID_SERVICE_ACCOUNT_BASE64 = Buffer.from(VALID_SERVICE_ACCOUNT_JSON, 'utf8').toString(
+  'base64',
+);
 
 function baseEnv(overrides: Record<string, string> = {}): Record<string, string> {
   return {
@@ -22,8 +25,8 @@ function baseEnv(overrides: Record<string, string> = {}): Record<string, string>
 }
 
 describe('createContainer', () => {
-  it('GOOGLE_SERVICE_ACCOUNT_KEY で Container を生成できる', () => {
-    const env = baseEnv({ GOOGLE_SERVICE_ACCOUNT_KEY: VALID_SERVICE_ACCOUNT_JSON });
+  it('GOOGLE_SERVICE_ACCOUNT_BASE64 で Container を生成できる', () => {
+    const env = baseEnv({ GOOGLE_SERVICE_ACCOUNT_BASE64: VALID_SERVICE_ACCOUNT_BASE64 });
     const container = createContainer(env);
     expect(container.getListPendingOrdersUseCase).toBeDefined();
   });
@@ -40,27 +43,33 @@ describe('createContainer', () => {
   });
 
   it('GOOGLE_SHEETS_SPREADSHEET_ID がない場合はエラーを投げる', () => {
-    const env = { GOOGLE_SERVICE_ACCOUNT_KEY: VALID_SERVICE_ACCOUNT_JSON };
+    const env = { GOOGLE_SERVICE_ACCOUNT_BASE64: VALID_SERVICE_ACCOUNT_BASE64 };
     expect(() => createContainer(env)).toThrow('GOOGLE_SHEETS_SPREADSHEET_ID is not configured');
   });
 
-  it('不正な JSON の GOOGLE_SERVICE_ACCOUNT_KEY はエラーを投げる', () => {
-    const env = baseEnv({ GOOGLE_SERVICE_ACCOUNT_KEY: 'not-json' });
-    expect(() => createContainer(env)).toThrow('JSON パースに失敗しました');
+  it('不正な BASE64 の GOOGLE_SERVICE_ACCOUNT_BASE64 はエラーを投げる', () => {
+    const env = baseEnv({ GOOGLE_SERVICE_ACCOUNT_BASE64: '!!!' });
+    expect(() => createContainer(env)).toThrow('デコードまたは JSON パースに失敗しました');
   });
 
-  it('client_email が欠けた GOOGLE_SERVICE_ACCOUNT_KEY はエラーを投げる', () => {
+  it('client_email が欠けた GOOGLE_SERVICE_ACCOUNT_BASE64 はエラーを投げる', () => {
     const env = baseEnv({
-      GOOGLE_SERVICE_ACCOUNT_KEY: JSON.stringify({ private_key: TEST_PRIVATE_KEY }),
+      GOOGLE_SERVICE_ACCOUNT_BASE64: Buffer.from(
+        JSON.stringify({ private_key: TEST_PRIVATE_KEY }),
+        'utf8',
+      ).toString('base64'),
     });
     expect(() => createContainer(env)).toThrow('client_email と private_key が含まれていません');
   });
 
-  it('private_key が欠けた GOOGLE_SERVICE_ACCOUNT_KEY はエラーを投げる', () => {
+  it('private_key が欠けた GOOGLE_SERVICE_ACCOUNT_BASE64 はエラーを投げる', () => {
     const env = baseEnv({
-      GOOGLE_SERVICE_ACCOUNT_KEY: JSON.stringify({
-        client_email: 'test@test.iam.gserviceaccount.com',
-      }),
+      GOOGLE_SERVICE_ACCOUNT_BASE64: Buffer.from(
+        JSON.stringify({
+          client_email: 'test@test.iam.gserviceaccount.com',
+        }),
+        'utf8',
+      ).toString('base64'),
     });
     expect(() => createContainer(env)).toThrow('client_email と private_key が含まれていません');
   });


### PR DESCRIPTION
## 概要
- Google Sheets 認証で GOOGLE_SERVICE_ACCOUNT_KEY ではなく GOOGLE_SERVICE_ACCOUNT_BASE64 を利用するよう変更
- base64 デコード後の JSON を検証し、エラーメッセージも新しい環境変数名に更新
- .env.example と README に設定方法・生成コマンドを追加

## 変更ファイル
- src/infrastructure/di/container.ts
- src/infrastructure/di/__tests__/container.test.ts
- .env.example
- README.md

## テスト
- npm test -- src/infrastructure/di/__tests__/container.test.ts
