### PR TITLE
fix: ヤマトPUDOの完了条件をアドレス帳登録クリックに変更

### DIFF
--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -302,6 +302,14 @@ class CreemaAdapter implements OrderFetcher {
 }
 ```
 
+#### 購入者名（buyerName）の運用方針
+
+- `PlatformOrderData.buyerName` は「姓 + 半角/全角スペース + 名」の単一文字列で扱う
+- `BuyerName` は単一の値オブジェクトとして維持し、ドメイン層では姓/名へ分割しない
+- minne/creema 側が姓/名を別フィールドで返す場合も、アダプター層で連結して `buyerName` に渡す
+- クリックポスト/ヤマトなど外部フォーム都合の分割は、ドメインではなくアダプター層で吸収する
+- ヤマト連携では、姓欄へ氏名全体を入力し名欄を空で送信する挙動を許容する
+
 ### NotificationSender（通知送信ポート）
 
 通知を送信するポート。


### PR DESCRIPTION
## 概要
ヤマトPUDO連携の完了条件を、実運用に合わせて「お届け先アドレス帳の新規登録ボタン（NEXT_BTN）クリック成功」に変更しました。

## 変更内容
- `YamatoPudoPage` の完了判定を調整
  - `NEXT_BTN` クリック後の追加待機・エラーチェックを削除
  - クリック成功時点で処理成功として返却
- セレクタ強化
  - お届け先アドレス帳タイルのDOMに合わせたセレクタを追加
  - `issueButton` に `button#NEXT_BTN[name="_BTN_REGISTER"]` を追加
  - セレクタ探索タイムアウトを `1.5s -> 5s` に延長
- 氏名入力の許容範囲拡大
  - 購入者名がスペース区切りでない場合でも、姓欄に氏名全体・名欄空で送信
- ドキュメント追記
  - `buyerName` は単一文字列で扱う運用方針を `docs/domain/README.md` に明記
- テスト更新
  - スペース区切りでない氏名ケースを成功期待へ変更

## 確認
- `npm run test -- src/infrastructure/adapters/shipping/__tests__/YamatoCompactAdapter.test.ts`
- `npm run lint -- src/infrastructure/external/playwright/YamatoPudoPage.ts`

