### PR TITLE
feat: #57 GmailClient を実装（購入通知判定・注文ID抽出）

### DIFF
--- a/src/infrastructure/external/google/GmailClient.ts
+++ b/src/infrastructure/external/google/GmailClient.ts
@@ -1,0 +1,240 @@
+import { AuthenticationError, ExternalServiceError } from '@/infrastructure/errors/HttpErrors';
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+interface GmailMessageId {
+  id: string;
+}
+
+interface GmailMessagesListResponse {
+  messages?: GmailMessageId[];
+}
+
+interface GmailHeader {
+  name: string;
+  value: string;
+}
+
+interface GmailBody {
+  data?: string;
+}
+
+interface GmailPayload {
+  headers?: GmailHeader[];
+  body?: GmailBody;
+  parts?: GmailPayload[];
+  mimeType?: string;
+}
+
+interface GmailMessageGetResponse {
+  id: string;
+  snippet?: string;
+  internalDate?: string;
+  payload?: GmailPayload;
+}
+
+export type PurchasePlatform = 'minne' | 'creema';
+
+export interface GmailMessage {
+  readonly id: string;
+  readonly subject: string;
+  readonly from: string;
+  readonly body: string;
+  readonly internalDate?: string;
+}
+
+export interface PurchaseNotification {
+  readonly messageId: string;
+  readonly platform: PurchasePlatform;
+  readonly orderId: string;
+  readonly subject: string;
+  readonly receivedAt?: string;
+}
+
+export interface GmailClientConfig {
+  readonly accessToken: string;
+  readonly baseUrl?: string;
+}
+
+const DEFAULT_QUERY = 'is:unread newer_than:7d (from:minne.com OR from:creema.jp)';
+const DEFAULT_BASE_URL = 'https://gmail.googleapis.com/gmail/v1/users/me';
+
+export class GmailClient {
+  private readonly baseUrl: string;
+  private readonly accessToken: string;
+  private readonly fetcher: FetchLike;
+
+  constructor(config: GmailClientConfig, fetcher: FetchLike = fetch) {
+    const accessToken = config.accessToken.trim();
+    if (!accessToken) {
+      throw new AuthenticationError('Gmail API のアクセストークンが設定されていません');
+    }
+    this.accessToken = accessToken;
+    this.baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+    this.fetcher = fetcher;
+  }
+
+  async listUnreadPurchaseNotifications(
+    query: string = DEFAULT_QUERY,
+  ): Promise<PurchaseNotification[]> {
+    const messages = await this.listMessages(query);
+    const notifications: PurchaseNotification[] = [];
+
+    for (const message of messages) {
+      const platform = this.detectPlatform(message.from);
+      if (!platform || !GmailClient.isPurchaseNotification(message)) {
+        continue;
+      }
+
+      const orderId = GmailClient.extractOrderId(message.body);
+      if (!orderId) {
+        continue;
+      }
+
+      notifications.push({
+        messageId: message.id,
+        platform,
+        orderId,
+        subject: message.subject,
+        receivedAt: message.internalDate,
+      });
+    }
+
+    return notifications;
+  }
+
+  async listMessages(query: string, maxResults: number = 20): Promise<GmailMessage[]> {
+    const listUrl = new URL(`${this.baseUrl}/messages`);
+    listUrl.searchParams.set('q', query);
+    listUrl.searchParams.set('maxResults', String(maxResults));
+
+    const listResponse = await this.request(listUrl.toString(), {
+      method: 'GET',
+      headers: this.buildAuthHeaders(),
+    });
+    const listPayload = (await listResponse.json()) as GmailMessagesListResponse;
+    const messages = listPayload.messages ?? [];
+
+    const detailedMessages: GmailMessage[] = [];
+    for (const message of messages) {
+      const detail = await this.getMessage(message.id);
+      detailedMessages.push(detail);
+    }
+
+    return detailedMessages;
+  }
+
+  async getMessage(messageId: string): Promise<GmailMessage> {
+    const detailUrl = new URL(`${this.baseUrl}/messages/${messageId}`);
+    detailUrl.searchParams.set('format', 'full');
+
+    const response = await this.request(detailUrl.toString(), {
+      method: 'GET',
+      headers: this.buildAuthHeaders(),
+    });
+    const payload = (await response.json()) as GmailMessageGetResponse;
+    const headers = payload.payload?.headers ?? [];
+    const subject = this.getHeader(headers, 'subject');
+    const from = this.getHeader(headers, 'from');
+    const body = this.extractBody(payload.payload) || payload.snippet || '';
+
+    return {
+      id: payload.id,
+      subject,
+      from,
+      body,
+      internalDate: payload.internalDate,
+    };
+  }
+
+  static isPurchaseNotification(message: GmailMessage): boolean {
+    const from = message.from.toLowerCase();
+    const isTargetPlatform = from.includes('minne') || from.includes('creema');
+    if (!isTargetPlatform) {
+      return false;
+    }
+
+    const combinedText = `${message.subject}\n${message.body}`;
+    return /(購入|注文|売れました|取引|お買い上げ)/.test(combinedText);
+  }
+
+  static extractOrderId(body: string): string | null {
+    const patterns = [
+      /(?:注文(?:ID|番号)|オーダーID|取引ID|order(?:\s*id)?)[^\w-]*([A-Za-z0-9][A-Za-z0-9-]{4,})/i,
+      /#([A-Za-z0-9][A-Za-z0-9-]{5,})/,
+    ];
+
+    for (const pattern of patterns) {
+      const match = body.match(pattern);
+      const candidate = match?.[1]?.trim();
+      if (candidate) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  private buildAuthHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.accessToken}`,
+    };
+  }
+
+  private async request(url: string, init: RequestInit): Promise<Response> {
+    const response = await this.fetcher(url, init);
+    if (!response.ok) {
+      throw new ExternalServiceError(
+        `Gmail API リクエストに失敗しました (status=${response.status})`,
+      );
+    }
+    return response;
+  }
+
+  private detectPlatform(from: string): PurchasePlatform | null {
+    const lowerFrom = from.toLowerCase();
+    if (lowerFrom.includes('minne')) {
+      return 'minne';
+    }
+    if (lowerFrom.includes('creema')) {
+      return 'creema';
+    }
+    return null;
+  }
+
+  private getHeader(headers: GmailHeader[], name: string): string {
+    const header = headers.find((item) => item.name.toLowerCase() === name.toLowerCase());
+    return header?.value ?? '';
+  }
+
+  private extractBody(payload?: GmailPayload): string {
+    if (!payload) {
+      return '';
+    }
+
+    if (payload.body?.data) {
+      return this.decodeBase64Url(payload.body.data);
+    }
+
+    const parts = payload.parts ?? [];
+    for (const part of parts) {
+      if (part.mimeType === 'text/plain' && part.body?.data) {
+        return this.decodeBase64Url(part.body.data);
+      }
+    }
+
+    for (const part of parts) {
+      const nested = this.extractBody(part);
+      if (nested) {
+        return nested;
+      }
+    }
+
+    return '';
+  }
+
+  private decodeBase64Url(value: string): string {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const padding = '='.repeat((4 - (normalized.length % 4)) % 4);
+    return Buffer.from(normalized + padding, 'base64').toString('utf8');
+  }
+}

--- a/src/infrastructure/external/google/__tests__/GmailClient.test.ts
+++ b/src/infrastructure/external/google/__tests__/GmailClient.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthenticationError, ExternalServiceError } from '@/infrastructure/errors/HttpErrors';
+import { GmailClient } from '../GmailClient';
+
+function toBase64Url(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64url');
+}
+
+describe('GmailClient', () => {
+  it('アクセストークン未設定は AuthenticationError を投げる', () => {
+    expect(() => new GmailClient({ accessToken: '   ' })).toThrow(AuthenticationError);
+  });
+
+  it('購入通知メールを判定し、注文IDを抽出できる', async () => {
+    const fetcher = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
+
+    fetcher.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          messages: [{ id: 'm1' }, { id: 'm2' }],
+        }),
+        { status: 200 },
+      ),
+    );
+    fetcher.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'm1',
+          payload: {
+            headers: [
+              { name: 'Subject', value: 'minneで商品が購入されました' },
+              { name: 'From', value: 'no-reply@minne.com' },
+            ],
+            body: { data: toBase64Url('注文ID: MN-123456') },
+          },
+          internalDate: '1700000000000',
+        }),
+        { status: 200 },
+      ),
+    );
+    fetcher.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'm2',
+          payload: {
+            headers: [
+              { name: 'Subject', value: 'Creema購入通知' },
+              { name: 'From', value: 'notice@creema.jp' },
+            ],
+            parts: [
+              {
+                mimeType: 'text/plain',
+                body: { data: toBase64Url('ご注文番号：CR-999999') },
+              },
+            ],
+          },
+          internalDate: '1700000001000',
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const client = new GmailClient(
+      {
+        accessToken: 'access-token',
+      },
+      fetcher,
+    );
+
+    const notifications = await client.listUnreadPurchaseNotifications();
+    expect(notifications).toEqual([
+      {
+        messageId: 'm1',
+        platform: 'minne',
+        orderId: 'MN-123456',
+        subject: 'minneで商品が購入されました',
+        receivedAt: '1700000000000',
+      },
+      {
+        messageId: 'm2',
+        platform: 'creema',
+        orderId: 'CR-999999',
+        subject: 'Creema購入通知',
+        receivedAt: '1700000001000',
+      },
+    ]);
+  });
+
+  it('購入通知でないメールは除外される', async () => {
+    const fetcher = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
+
+    fetcher.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          messages: [{ id: 'm1' }],
+        }),
+        { status: 200 },
+      ),
+    );
+    fetcher.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'm1',
+          payload: {
+            headers: [
+              { name: 'Subject', value: '通常のお知らせ' },
+              { name: 'From', value: 'notice@example.com' },
+            ],
+            body: { data: toBase64Url('本文') },
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const client = new GmailClient({ accessToken: 'access-token' }, fetcher);
+    const notifications = await client.listUnreadPurchaseNotifications();
+    expect(notifications).toEqual([]);
+  });
+
+  it('Gmail API エラー時は ExternalServiceError を投げる', async () => {
+    const fetcher = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
+    fetcher.mockResolvedValueOnce(new Response('error', { status: 503 }));
+
+    const client = new GmailClient({ accessToken: 'access-token' }, fetcher);
+    await expect(client.listUnreadPurchaseNotifications()).rejects.toThrow(ExternalServiceError);
+  });
+
+  it('extractOrderId は本文から注文IDを抽出する', () => {
+    expect(GmailClient.extractOrderId('注文番号: AB-123456')).toBe('AB-123456');
+    expect(GmailClient.extractOrderId('Order ID #ZXCVB12345')).toBe('ZXCVB12345');
+    expect(GmailClient.extractOrderId('注文情報なし')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要
#57（#26-1）として、Gmail API 連携の基盤 `GmailClient` を実装しました。

- Gmail API からメッセージ一覧・詳細取得
- minne/creema の購入通知メール判定
- メール本文から注文ID抽出

※ 親イシュー #26 の最終チェックは #59 のタイミングで実施する前提です（今回は #57 範囲のみ対応）。

## 変更内容
- `src/infrastructure/external/google/GmailClient.ts`
  - `listMessages(query, maxResults)`
  - `getMessage(messageId)`
  - `listUnreadPurchaseNotifications()`
  - `isPurchaseNotification()`
  - `extractOrderId()`
- `src/infrastructure/external/google/__tests__/GmailClient.test.ts`
  - アクセストークン未設定エラー
  - 購入通知判定 + 注文ID抽出
  - 非対象メール除外
  - Gmail API エラー
  - 抽出ロジック単体

## テスト
- `npm run lint`
- `npm run test -- src/infrastructure/external/google/__tests__/GmailClient.test.ts`
- `npm run test`
- `npm run build`

Closes #57
