### PR TITLE
feat: #58 MinneAdapter + MinnePage を実装

### DIFF
--- a/src/infrastructure/adapters/platform/MinneAdapter.ts
+++ b/src/infrastructure/adapters/platform/MinneAdapter.ts
@@ -1,0 +1,64 @@
+import { OrderFetcher, PlatformOrderData } from '@/domain/ports/OrderFetcher';
+import { OrderId } from '@/domain/valueObjects/OrderId';
+import { Platform } from '@/domain/valueObjects/Platform';
+import {
+  MinneCredentials,
+  MinnePage,
+  MinnePageLike,
+  MinneScrapedOrderData,
+} from '@/infrastructure/external/playwright/MinnePage';
+
+export interface MinneBrowserLike {
+  newPage(): Promise<MinnePageLike>;
+  close(): Promise<void>;
+}
+
+export interface MinneBrowserFactory {
+  launch(): Promise<MinneBrowserLike>;
+}
+
+interface MinneAdapterDependencies {
+  readonly browserFactory: MinneBrowserFactory;
+  readonly credentials: MinneCredentials;
+}
+
+export class MinneAdapter implements OrderFetcher {
+  constructor(private readonly dependencies: MinneAdapterDependencies) {}
+
+  async fetch(orderId: OrderId, platform: Platform): Promise<PlatformOrderData> {
+    if (!platform.equals(Platform.Minne)) {
+      throw new Error(`MinneAdapter は minne 専用です: ${platform.toString()}`);
+    }
+
+    const browser = await this.dependencies.browserFactory.launch();
+    try {
+      const page = await browser.newPage();
+      const minnePage = new MinnePage(page);
+      const scraped = await minnePage.fetchOrder(orderId, this.dependencies.credentials);
+      return this.toPlatformOrderData(orderId, scraped);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`minne 注文取得に失敗しました: ${message}`, { cause: error });
+    } finally {
+      await browser.close().catch((closeError) => {
+        console.warn('[MinneAdapter] browser.close に失敗しました', closeError);
+      });
+    }
+  }
+
+  private toPlatformOrderData(orderId: OrderId, scraped: MinneScrapedOrderData): PlatformOrderData {
+    return {
+      orderId: orderId.toString(),
+      platform: Platform.Minne,
+      buyerName: scraped.buyerName,
+      buyerPostalCode: scraped.buyerPostalCode,
+      buyerPrefecture: scraped.buyerPrefecture,
+      buyerCity: scraped.buyerCity,
+      buyerAddress1: scraped.buyerAddress1,
+      buyerAddress2: scraped.buyerAddress2,
+      buyerPhone: scraped.buyerPhone,
+      productName: scraped.productName,
+      orderedAt: scraped.orderedAt,
+    };
+  }
+}

--- a/src/infrastructure/adapters/platform/__tests__/MinneAdapter.test.ts
+++ b/src/infrastructure/adapters/platform/__tests__/MinneAdapter.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OrderFactory } from '@/domain/factories/OrderFactory';
+import { OrderFetcher } from '@/domain/ports/OrderFetcher';
+import { OrderId } from '@/domain/valueObjects/OrderId';
+import { Platform } from '@/domain/valueObjects/Platform';
+import { MinneAdapter, MinneBrowserFactory } from '../MinneAdapter';
+
+function createTextContentMock(values: Record<string, string>) {
+  return vi.fn(async (selector: string) => values[selector] ?? null);
+}
+
+describe('MinneAdapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('OrderFetcher を実装し、minne 注文情報を PlatformOrderData として返す', async () => {
+    const fill = vi.fn(async () => undefined);
+    const click = vi.fn(async () => undefined);
+    const goto = vi.fn(async () => undefined);
+    const close = vi.fn(async () => undefined);
+    const textContent = createTextContentMock({
+      '.buyer-name': '山田 花子',
+      '.shipping-postal-code': '150-0001',
+      '.shipping-prefecture': '東京都',
+      '.shipping-city': '渋谷区',
+      '.shipping-address-line1': '神宮前1-2-3',
+      '.shipping-address-line2': 'サンプルビル101',
+      '.shipping-phone': '090-1234-5678',
+      '.product-name': 'ハンドメイドピアス',
+      '.ordered-at': '2026-02-22T12:34:56.000Z',
+    });
+
+    const browserFactory: MinneBrowserFactory = {
+      launch: vi.fn(async () => ({
+        newPage: vi.fn(async () => ({
+          goto,
+          fill,
+          click,
+          textContent,
+        })),
+        close,
+      })),
+    };
+
+    const adapter = new MinneAdapter({
+      browserFactory,
+      credentials: {
+        email: 'minne@example.com',
+        password: 'secret',
+      },
+    });
+    const fetcher: OrderFetcher = adapter;
+
+    const data = await fetcher.fetch(new OrderId('MN-00001'), Platform.Minne);
+    expect(data).toEqual({
+      orderId: 'MN-00001',
+      platform: Platform.Minne,
+      buyerName: '山田 花子',
+      buyerPostalCode: '1500001',
+      buyerPrefecture: '東京都',
+      buyerCity: '渋谷区',
+      buyerAddress1: '神宮前1-2-3',
+      buyerAddress2: 'サンプルビル101',
+      buyerPhone: '09012345678',
+      productName: 'ハンドメイドピアス',
+      orderedAt: new Date('2026-02-22T12:34:56.000Z'),
+    });
+    expect(goto).toHaveBeenCalledWith('https://minne.com/signin');
+    expect(goto).toHaveBeenCalledWith('https://minne.com/orders/MN-00001');
+    expect(fill).toHaveBeenCalledWith('#email', 'minne@example.com');
+    expect(fill).toHaveBeenCalledWith('#password', 'secret');
+    expect(click).toHaveBeenCalledWith('button[type="submit"]');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('OrderFactory.createFromPlatformData で Order に変換できる', async () => {
+    const textContent = createTextContentMock({
+      '.buyer-name': '山田 花子',
+      '.shipping-postal-code': '150-0001',
+      '.shipping-prefecture': '東京都',
+      '.shipping-city': '渋谷区',
+      '.shipping-address-line1': '神宮前1-2-3',
+      '.product-name': 'ハンドメイドピアス',
+      '.ordered-at': '2026-02-22T12:34:56.000Z',
+    });
+    const browserFactory: MinneBrowserFactory = {
+      launch: vi.fn(async () => ({
+        newPage: vi.fn(async () => ({
+          goto: vi.fn(async () => undefined),
+          fill: vi.fn(async () => undefined),
+          click: vi.fn(async () => undefined),
+          textContent,
+        })),
+        close: vi.fn(async () => undefined),
+      })),
+    };
+    const adapter = new MinneAdapter({
+      browserFactory,
+      credentials: { email: 'minne@example.com', password: 'secret' },
+    });
+
+    const raw = await adapter.fetch(new OrderId('MN-00002'), Platform.Minne);
+    const order = new OrderFactory().createFromPlatformData(raw);
+
+    expect(order.orderId.toString()).toBe('MN-00002');
+    expect(order.platform.toString()).toBe('minne');
+    expect(order.buyer.name.toString()).toBe('山田 花子');
+    expect(order.product.name).toBe('ハンドメイドピアス');
+  });
+
+  it('minne 以外の platform 指定はエラー', async () => {
+    const browserFactory: MinneBrowserFactory = {
+      launch: vi.fn(async () => ({
+        newPage: vi.fn(),
+        close: vi.fn(async () => undefined),
+      })),
+    };
+    const adapter = new MinneAdapter({
+      browserFactory,
+      credentials: { email: 'minne@example.com', password: 'secret' },
+    });
+
+    await expect(adapter.fetch(new OrderId('CR-00001'), Platform.Creema)).rejects.toThrow(
+      'MinneAdapter は minne 専用です: creema',
+    );
+    expect(browserFactory.launch).not.toHaveBeenCalled();
+  });
+});

--- a/src/infrastructure/external/playwright/MinnePage.ts
+++ b/src/infrastructure/external/playwright/MinnePage.ts
@@ -1,0 +1,154 @@
+import { OrderId } from '@/domain/valueObjects/OrderId';
+
+const MINNE_LOGIN_URL = 'https://minne.com/signin';
+const MINNE_ORDER_DETAIL_URL = 'https://minne.com/orders';
+
+const SELECTORS = {
+  email: ['#email', 'input[name="email"]', 'input[type="email"]'] as const,
+  password: ['#password', 'input[name="password"]', 'input[type="password"]'] as const,
+  loginButton: ['button[type="submit"]', 'input[type="submit"]', 'text=ログイン'] as const,
+  buyerName: ['.buyer-name', '[data-testid="buyer-name"]', '#buyer-name'] as const,
+  postalCode: ['.shipping-postal-code', '[data-testid="postal-code"]', '#postal-code'] as const,
+  prefecture: ['.shipping-prefecture', '[data-testid="prefecture"]', '#prefecture'] as const,
+  city: ['.shipping-city', '[data-testid="city"]', '#city'] as const,
+  address1: ['.shipping-address-line1', '[data-testid="address1"]', '#address1'] as const,
+  address2: ['.shipping-address-line2', '[data-testid="address2"]', '#address2'] as const,
+  phone: ['.shipping-phone', '[data-testid="phone"]', '#phone'] as const,
+  productName: ['.product-name', '[data-testid="product-name"]', '#product-name'] as const,
+  orderedAt: ['.ordered-at', '[data-testid="ordered-at"]', '#ordered-at'] as const,
+} as const;
+
+export interface MinneCredentials {
+  readonly email: string;
+  readonly password: string;
+}
+
+export interface MinnePageLike {
+  goto(url: string, options?: { timeout?: number }): Promise<void>;
+  fill(selector: string, value: string): Promise<void>;
+  click(selector: string, options?: { timeout?: number }): Promise<void>;
+  textContent(selector: string): Promise<string | null>;
+}
+
+export interface MinneScrapedOrderData {
+  readonly buyerName: string;
+  readonly buyerPostalCode: string;
+  readonly buyerPrefecture: string;
+  readonly buyerCity: string;
+  readonly buyerAddress1: string;
+  readonly buyerAddress2?: string;
+  readonly buyerPhone?: string;
+  readonly productName: string;
+  readonly orderedAt: Date;
+}
+
+export class MinnePage {
+  constructor(private readonly page: MinnePageLike) {}
+
+  async fetchOrder(
+    orderId: OrderId,
+    credentials: MinneCredentials,
+  ): Promise<MinneScrapedOrderData> {
+    await this.login(credentials);
+    await this.openOrder(orderId);
+    return this.scrapeOrder();
+  }
+
+  private async login(credentials: MinneCredentials): Promise<void> {
+    await this.page.goto(MINNE_LOGIN_URL);
+
+    const emailFilled = await this.fillFirst([...SELECTORS.email], credentials.email);
+    if (!emailFilled) {
+      throw new Error('minne ログインメール入力欄を検出できませんでした');
+    }
+
+    const passwordFilled = await this.fillFirst([...SELECTORS.password], credentials.password);
+    if (!passwordFilled) {
+      throw new Error('minne ログインパスワード入力欄を検出できませんでした');
+    }
+
+    const clicked = await this.clickFirst([...SELECTORS.loginButton]);
+    if (!clicked) {
+      throw new Error('minne ログインボタンを検出できませんでした');
+    }
+  }
+
+  private async openOrder(orderId: OrderId): Promise<void> {
+    await this.page.goto(`${MINNE_ORDER_DETAIL_URL}/${encodeURIComponent(orderId.toString())}`);
+  }
+
+  private async scrapeOrder(): Promise<MinneScrapedOrderData> {
+    const buyerName = await this.requiredText([...SELECTORS.buyerName], '購入者名');
+    const buyerPostalCode = await this.requiredText([...SELECTORS.postalCode], '郵便番号');
+    const buyerPrefecture = await this.requiredText([...SELECTORS.prefecture], '都道府県');
+    const buyerCity = await this.requiredText([...SELECTORS.city], '市区町村');
+    const buyerAddress1 = await this.requiredText([...SELECTORS.address1], '番地');
+    const buyerAddress2 = await this.optionalText([...SELECTORS.address2]);
+    const buyerPhone = await this.optionalText([...SELECTORS.phone]);
+    const productName = await this.requiredText([...SELECTORS.productName], '商品名');
+    const orderedAtText = await this.requiredText([...SELECTORS.orderedAt], '注文日時');
+    const orderedAt = new Date(orderedAtText);
+    if (Number.isNaN(orderedAt.getTime())) {
+      throw new Error(`注文日時の形式が不正です: ${orderedAtText}`);
+    }
+
+    return {
+      buyerName,
+      buyerPostalCode: buyerPostalCode.replace(/[^\d]/g, ''),
+      buyerPrefecture,
+      buyerCity,
+      buyerAddress1,
+      buyerAddress2: buyerAddress2 || undefined,
+      buyerPhone: buyerPhone?.replace(/[^\d]/g, '') || undefined,
+      productName,
+      orderedAt,
+    };
+  }
+
+  private async fillFirst(selectors: string[], value: string): Promise<boolean> {
+    for (const selector of selectors) {
+      try {
+        await this.page.fill(selector, value);
+        return true;
+      } catch {
+        // try next selector
+      }
+    }
+    return false;
+  }
+
+  private async clickFirst(selectors: string[]): Promise<boolean> {
+    for (const selector of selectors) {
+      try {
+        await this.page.click(selector);
+        return true;
+      } catch {
+        // try next selector
+      }
+    }
+    return false;
+  }
+
+  private async requiredText(selectors: string[], fieldLabel: string): Promise<string> {
+    const value = await this.optionalText(selectors);
+    if (!value) {
+      throw new Error(`minne 注文詳細の${fieldLabel}を取得できませんでした`);
+    }
+    return value;
+  }
+
+  private async optionalText(selectors: string[]): Promise<string | null> {
+    for (const selector of selectors) {
+      try {
+        const text = await this.page.textContent(selector);
+        const normalized = text?.trim();
+        if (normalized) {
+          return normalized;
+        }
+      } catch {
+        // try next selector
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## 概要
#58（#26-2）として、minne から購入者情報を取得する `MinneAdapter` と `MinnePage` を実装しました。

- `MinneAdapter` が `OrderFetcher` を実装
- `MinnePage` でログイン・注文詳細アクセス・項目抽出を実施
- 取得した `PlatformOrderData` を `OrderFactory` で `Order` に変換できることをテストで確認

※ 親 #26 の最終チェックは #59 のタイミングで実施予定です（今回は #58 範囲のみ対応）。

## 変更内容
- `src/infrastructure/adapters/platform/MinneAdapter.ts`
  - `OrderFetcher` 実装
  - browser/page のライフサイクル管理
  - `Platform.Minne` 専用チェック
- `src/infrastructure/external/playwright/MinnePage.ts`
  - ログイン処理
  - 注文詳細ページ遷移
  - 購入者情報・商品情報・注文日時の抽出
- `src/infrastructure/adapters/platform/__tests__/MinneAdapter.test.ts`
  - `OrderFetcher` 実装確認
  - `OrderFactory.createFromPlatformData()` 接続確認
  - platform 不一致エラー確認

## テスト
- `npm run lint`
- `npm run test -- src/infrastructure/adapters/platform/__tests__/MinneAdapter.test.ts`
- `npm run test`
- `npm run build`

Closes #58
