### PR TITLE
feat: #59 CreemaAdapter + CreemaPage を実装

### DIFF
--- a/src/infrastructure/adapters/platform/CreemaAdapter.ts
+++ b/src/infrastructure/adapters/platform/CreemaAdapter.ts
@@ -1,0 +1,67 @@
+import { OrderFetcher, PlatformOrderData } from '@/domain/ports/OrderFetcher';
+import { OrderId } from '@/domain/valueObjects/OrderId';
+import { Platform } from '@/domain/valueObjects/Platform';
+import {
+  CreemaCredentials,
+  CreemaPage,
+  CreemaPageLike,
+  CreemaScrapedOrderData,
+} from '@/infrastructure/external/playwright/CreemaPage';
+
+export interface CreemaBrowserLike {
+  newPage(): Promise<CreemaPageLike>;
+  close(): Promise<void>;
+}
+
+export interface CreemaBrowserFactory {
+  launch(): Promise<CreemaBrowserLike>;
+}
+
+interface CreemaAdapterDependencies {
+  readonly browserFactory: CreemaBrowserFactory;
+  readonly credentials: CreemaCredentials;
+}
+
+export class CreemaAdapter implements OrderFetcher {
+  constructor(private readonly dependencies: CreemaAdapterDependencies) {}
+
+  async fetch(orderId: OrderId, platform: Platform): Promise<PlatformOrderData> {
+    if (!platform.equals(Platform.Creema)) {
+      throw new Error(`CreemaAdapter は creema 専用です: ${platform.toString()}`);
+    }
+
+    const browser = await this.dependencies.browserFactory.launch();
+    try {
+      const page = await browser.newPage();
+      const creemaPage = new CreemaPage(page);
+      const scraped = await creemaPage.fetchOrder(orderId, this.dependencies.credentials);
+      return this.toPlatformOrderData(orderId, scraped);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`creema 注文取得に失敗しました: ${message}`, { cause: error });
+    } finally {
+      await browser.close().catch((closeError) => {
+        console.warn('[CreemaAdapter] browser.close に失敗しました', closeError);
+      });
+    }
+  }
+
+  private toPlatformOrderData(
+    orderId: OrderId,
+    scraped: CreemaScrapedOrderData,
+  ): PlatformOrderData {
+    return {
+      orderId: orderId.toString(),
+      platform: Platform.Creema,
+      buyerName: scraped.buyerName,
+      buyerPostalCode: scraped.buyerPostalCode,
+      buyerPrefecture: scraped.buyerPrefecture,
+      buyerCity: scraped.buyerCity,
+      buyerAddress1: scraped.buyerAddress1,
+      buyerAddress2: scraped.buyerAddress2,
+      buyerPhone: scraped.buyerPhone,
+      productName: scraped.productName,
+      orderedAt: scraped.orderedAt,
+    };
+  }
+}

--- a/src/infrastructure/adapters/platform/__tests__/CreemaAdapter.test.ts
+++ b/src/infrastructure/adapters/platform/__tests__/CreemaAdapter.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OrderFactory } from '@/domain/factories/OrderFactory';
+import { OrderFetcher } from '@/domain/ports/OrderFetcher';
+import { OrderId } from '@/domain/valueObjects/OrderId';
+import { Platform } from '@/domain/valueObjects/Platform';
+import { CreemaAdapter, CreemaBrowserFactory } from '../CreemaAdapter';
+
+function createTextContentMock(values: Record<string, string>) {
+  return vi.fn(async (selector: string) => values[selector] ?? null);
+}
+
+describe('CreemaAdapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('OrderFetcher を実装し、creema 注文情報を PlatformOrderData として返す', async () => {
+    const fill = vi.fn(async () => undefined);
+    const click = vi.fn(async () => undefined);
+    const goto = vi.fn(async () => undefined);
+    const close = vi.fn(async () => undefined);
+    const textContent = createTextContentMock({
+      '.buyer-name': '佐藤 愛',
+      '.shipping-postal-code': '530-0001',
+      '.shipping-prefecture': '大阪府',
+      '.shipping-city': '大阪市北区',
+      '.shipping-address-line1': '梅田1-1-1',
+      '.shipping-address-line2': 'サンプルマンション202',
+      '.shipping-phone': '080-9876-5432',
+      '.product-name': 'ハンドメイドバッグ',
+      '.ordered-at': '2026-02-25T10:00:00.000Z',
+    });
+
+    const browserFactory: CreemaBrowserFactory = {
+      launch: vi.fn(async () => ({
+        newPage: vi.fn(async () => ({
+          goto,
+          fill,
+          click,
+          textContent,
+        })),
+        close,
+      })),
+    };
+
+    const adapter = new CreemaAdapter({
+      browserFactory,
+      credentials: {
+        email: 'creema@example.com',
+        password: 'secret',
+      },
+    });
+    const fetcher: OrderFetcher = adapter;
+
+    const data = await fetcher.fetch(new OrderId('CR-10001'), Platform.Creema);
+    expect(data).toEqual({
+      orderId: 'CR-10001',
+      platform: Platform.Creema,
+      buyerName: '佐藤 愛',
+      buyerPostalCode: '5300001',
+      buyerPrefecture: '大阪府',
+      buyerCity: '大阪市北区',
+      buyerAddress1: '梅田1-1-1',
+      buyerAddress2: 'サンプルマンション202',
+      buyerPhone: '08098765432',
+      productName: 'ハンドメイドバッグ',
+      orderedAt: new Date('2026-02-25T10:00:00.000Z'),
+    });
+    expect(goto).toHaveBeenCalledWith('https://www.creema.jp/login');
+    expect(goto).toHaveBeenCalledWith('https://www.creema.jp/member/orders/CR-10001');
+    expect(fill).toHaveBeenCalledWith('#email', 'creema@example.com');
+    expect(fill).toHaveBeenCalledWith('#password', 'secret');
+    expect(click).toHaveBeenCalledWith('button[type="submit"]');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('OrderFactory.createFromPlatformData で Order に変換できる', async () => {
+    const textContent = createTextContentMock({
+      '.buyer-name': '佐藤 愛',
+      '.shipping-postal-code': '530-0001',
+      '.shipping-prefecture': '大阪府',
+      '.shipping-city': '大阪市北区',
+      '.shipping-address-line1': '梅田1-1-1',
+      '.product-name': 'ハンドメイドバッグ',
+      '.ordered-at': '2026-02-25T10:00:00.000Z',
+    });
+    const browserFactory: CreemaBrowserFactory = {
+      launch: vi.fn(async () => ({
+        newPage: vi.fn(async () => ({
+          goto: vi.fn(async () => undefined),
+          fill: vi.fn(async () => undefined),
+          click: vi.fn(async () => undefined),
+          textContent,
+        })),
+        close: vi.fn(async () => undefined),
+      })),
+    };
+    const adapter = new CreemaAdapter({
+      browserFactory,
+      credentials: { email: 'creema@example.com', password: 'secret' },
+    });
+
+    const raw = await adapter.fetch(new OrderId('CR-10002'), Platform.Creema);
+    const order = new OrderFactory().createFromPlatformData(raw);
+
+    expect(order.orderId.toString()).toBe('CR-10002');
+    expect(order.platform.toString()).toBe('creema');
+    expect(order.buyer.name.toString()).toBe('佐藤 愛');
+    expect(order.product.name).toBe('ハンドメイドバッグ');
+  });
+
+  it('creema 以外の platform 指定はエラー', async () => {
+    const browserFactory: CreemaBrowserFactory = {
+      launch: vi.fn(async () => ({
+        newPage: vi.fn(),
+        close: vi.fn(async () => undefined),
+      })),
+    };
+    const adapter = new CreemaAdapter({
+      browserFactory,
+      credentials: { email: 'creema@example.com', password: 'secret' },
+    });
+
+    await expect(adapter.fetch(new OrderId('MN-00001'), Platform.Minne)).rejects.toThrow(
+      'CreemaAdapter は creema 専用です: minne',
+    );
+    expect(browserFactory.launch).not.toHaveBeenCalled();
+  });
+});

--- a/src/infrastructure/external/playwright/CreemaPage.ts
+++ b/src/infrastructure/external/playwright/CreemaPage.ts
@@ -1,0 +1,154 @@
+import { OrderId } from '@/domain/valueObjects/OrderId';
+
+const CREEMA_LOGIN_URL = 'https://www.creema.jp/login';
+const CREEMA_ORDER_DETAIL_URL = 'https://www.creema.jp/member/orders';
+
+const SELECTORS = {
+  email: ['#email', 'input[name="email"]', 'input[type="email"]'] as const,
+  password: ['#password', 'input[name="password"]', 'input[type="password"]'] as const,
+  loginButton: ['button[type="submit"]', 'input[type="submit"]', 'text=ログイン'] as const,
+  buyerName: ['.buyer-name', '[data-testid="buyer-name"]', '#buyer-name'] as const,
+  postalCode: ['.shipping-postal-code', '[data-testid="postal-code"]', '#postal-code'] as const,
+  prefecture: ['.shipping-prefecture', '[data-testid="prefecture"]', '#prefecture'] as const,
+  city: ['.shipping-city', '[data-testid="city"]', '#city'] as const,
+  address1: ['.shipping-address-line1', '[data-testid="address1"]', '#address1'] as const,
+  address2: ['.shipping-address-line2', '[data-testid="address2"]', '#address2'] as const,
+  phone: ['.shipping-phone', '[data-testid="phone"]', '#phone'] as const,
+  productName: ['.product-name', '[data-testid="product-name"]', '#product-name'] as const,
+  orderedAt: ['.ordered-at', '[data-testid="ordered-at"]', '#ordered-at'] as const,
+} as const;
+
+export interface CreemaCredentials {
+  readonly email: string;
+  readonly password: string;
+}
+
+export interface CreemaPageLike {
+  goto(url: string, options?: { timeout?: number }): Promise<void>;
+  fill(selector: string, value: string): Promise<void>;
+  click(selector: string, options?: { timeout?: number }): Promise<void>;
+  textContent(selector: string): Promise<string | null>;
+}
+
+export interface CreemaScrapedOrderData {
+  readonly buyerName: string;
+  readonly buyerPostalCode: string;
+  readonly buyerPrefecture: string;
+  readonly buyerCity: string;
+  readonly buyerAddress1: string;
+  readonly buyerAddress2?: string;
+  readonly buyerPhone?: string;
+  readonly productName: string;
+  readonly orderedAt: Date;
+}
+
+export class CreemaPage {
+  constructor(private readonly page: CreemaPageLike) {}
+
+  async fetchOrder(
+    orderId: OrderId,
+    credentials: CreemaCredentials,
+  ): Promise<CreemaScrapedOrderData> {
+    await this.login(credentials);
+    await this.openOrder(orderId);
+    return this.scrapeOrder();
+  }
+
+  private async login(credentials: CreemaCredentials): Promise<void> {
+    await this.page.goto(CREEMA_LOGIN_URL);
+
+    const emailFilled = await this.fillFirst([...SELECTORS.email], credentials.email);
+    if (!emailFilled) {
+      throw new Error('creema ログインメール入力欄を検出できませんでした');
+    }
+
+    const passwordFilled = await this.fillFirst([...SELECTORS.password], credentials.password);
+    if (!passwordFilled) {
+      throw new Error('creema ログインパスワード入力欄を検出できませんでした');
+    }
+
+    const clicked = await this.clickFirst([...SELECTORS.loginButton]);
+    if (!clicked) {
+      throw new Error('creema ログインボタンを検出できませんでした');
+    }
+  }
+
+  private async openOrder(orderId: OrderId): Promise<void> {
+    await this.page.goto(`${CREEMA_ORDER_DETAIL_URL}/${encodeURIComponent(orderId.toString())}`);
+  }
+
+  private async scrapeOrder(): Promise<CreemaScrapedOrderData> {
+    const buyerName = await this.requiredText([...SELECTORS.buyerName], '購入者名');
+    const buyerPostalCode = await this.requiredText([...SELECTORS.postalCode], '郵便番号');
+    const buyerPrefecture = await this.requiredText([...SELECTORS.prefecture], '都道府県');
+    const buyerCity = await this.requiredText([...SELECTORS.city], '市区町村');
+    const buyerAddress1 = await this.requiredText([...SELECTORS.address1], '番地');
+    const buyerAddress2 = await this.optionalText([...SELECTORS.address2]);
+    const buyerPhone = await this.optionalText([...SELECTORS.phone]);
+    const productName = await this.requiredText([...SELECTORS.productName], '商品名');
+    const orderedAtText = await this.requiredText([...SELECTORS.orderedAt], '注文日時');
+    const orderedAt = new Date(orderedAtText);
+    if (Number.isNaN(orderedAt.getTime())) {
+      throw new Error(`注文日時の形式が不正です: ${orderedAtText}`);
+    }
+
+    return {
+      buyerName,
+      buyerPostalCode: buyerPostalCode.replace(/[^\d]/g, ''),
+      buyerPrefecture,
+      buyerCity,
+      buyerAddress1,
+      buyerAddress2: buyerAddress2 || undefined,
+      buyerPhone: buyerPhone?.replace(/[^\d]/g, '') || undefined,
+      productName,
+      orderedAt,
+    };
+  }
+
+  private async fillFirst(selectors: string[], value: string): Promise<boolean> {
+    for (const selector of selectors) {
+      try {
+        await this.page.fill(selector, value);
+        return true;
+      } catch {
+        // try next selector
+      }
+    }
+    return false;
+  }
+
+  private async clickFirst(selectors: string[]): Promise<boolean> {
+    for (const selector of selectors) {
+      try {
+        await this.page.click(selector);
+        return true;
+      } catch {
+        // try next selector
+      }
+    }
+    return false;
+  }
+
+  private async requiredText(selectors: string[], fieldLabel: string): Promise<string> {
+    const value = await this.optionalText(selectors);
+    if (!value) {
+      throw new Error(`creema 注文詳細の${fieldLabel}を取得できませんでした`);
+    }
+    return value;
+  }
+
+  private async optionalText(selectors: string[]): Promise<string | null> {
+    for (const selector of selectors) {
+      try {
+        const text = await this.page.textContent(selector);
+        const normalized = text?.trim();
+        if (normalized) {
+          return normalized;
+        }
+      } catch {
+        // try next selector
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## 概要
#59（#26-3）として、creema から購入者情報を取得する `CreemaAdapter` と `CreemaPage` を実装しました。

- `CreemaAdapter` が `OrderFetcher` を実装
- `CreemaPage` でログイン・注文詳細アクセス・項目抽出を実施
- 取得した `PlatformOrderData` を `OrderFactory` で `Order` に変換できることをテストで確認

## 変更内容
- `src/infrastructure/adapters/platform/CreemaAdapter.ts`
  - `OrderFetcher` 実装
  - browser/page のライフサイクル管理
  - `Platform.Creema` 専用チェック
- `src/infrastructure/external/playwright/CreemaPage.ts`
  - ログイン処理
  - 注文詳細ページ遷移
  - 購入者情報・商品情報・注文日時の抽出
- `src/infrastructure/adapters/platform/__tests__/CreemaAdapter.test.ts`
  - `OrderFetcher` 実装確認
  - `OrderFactory.createFromPlatformData()` 接続確認
  - platform 不一致エラー確認

## テスト
- `npm run lint`
- `npm run test -- src/infrastructure/adapters/platform/__tests__/CreemaAdapter.test.ts`
- `npm run test`
- `npm run build`

Closes #59
