### PR TITLE
feat: implement minne order fetching with Gmail magic link auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "prepare": "husky",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:minne": "npx tsx scripts/test-minne-fetch.ts",
+    "test:minne:batch": "npx tsx scripts/test-minne-batch-fetch.ts"
   },
   "dependencies": {
     "next": "^16.1.6",

--- a/scripts/test-minne-batch-fetch.ts
+++ b/scripts/test-minne-batch-fetch.ts
@@ -1,0 +1,260 @@
+/**
+ * minne 未登録注文の一括取得 → スプレッドシート保存スクリプト
+ *
+ * 実行方法:
+ *   npx tsx scripts/test-minne-batch-fetch.ts
+ *
+ * フロー:
+ *   1. minne にマジックリンクでログイン（Gmail 自動取得）
+ *   2. 注文一覧ページから全注文 ID を取得
+ *   3. スプシに未登録の注文だけを minne から個別に取得
+ *   4. OrderFactory で Order に変換してスプシに保存
+ *   5. 処理結果を表示
+ *
+ * .env.local から以下を自動読み込みします:
+ *   MINNE_EMAIL, GMAIL_REFRESH_TOKEN, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET,
+ *   GOOGLE_SERVICE_ACCOUNT_BASE64, GOOGLE_SHEETS_SPREADSHEET_ID, GOOGLE_SHEETS_SHEET_NAME
+ */
+
+import { chromium } from 'playwright';
+import { createInterface } from 'node:readline';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { OrderFactory } from '../src/domain/factories/OrderFactory';
+import { OrderId } from '../src/domain/valueObjects/OrderId';
+import { Platform } from '../src/domain/valueObjects/Platform';
+import { MinnePage } from '../src/infrastructure/external/playwright/MinnePage';
+import { GoogleGmailClient } from '../src/infrastructure/external/google/GmailClient';
+import { GoogleSheetsClient } from '../src/infrastructure/external/google/SheetsClient';
+import { SpreadsheetOrderRepository } from '../src/infrastructure/adapters/persistence/SpreadsheetOrderRepository';
+
+// ---- ユーティリティ ----
+
+function loadEnvFile(filePath: string): void {
+  if (!existsSync(filePath)) return;
+  const content = readFileSync(filePath, 'utf-8');
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.substring(0, eqIdx).trim();
+    let value = trimmed.substring(eqIdx + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!process.env[key]) process.env[key] = value;
+  }
+}
+
+function promptUser(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((res) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      res(answer.trim());
+    });
+  });
+}
+
+// ---- Gmail からログインリンク取得（test-minne-fetch.ts と同じロジック） ----
+
+async function fetchLoginUrl(sentAt: Date, email: string): Promise<string> {
+  const gmailClient = new GoogleGmailClient({
+    accessToken: process.env['GMAIL_ACCESS_TOKEN'],
+    refreshToken: process.env['GMAIL_REFRESH_TOKEN'],
+    clientId: process.env['GOOGLE_CLIENT_ID'],
+    clientSecret: process.env['GOOGLE_CLIENT_SECRET'],
+  });
+
+  const hasGmailCreds = Boolean(
+    process.env['GMAIL_ACCESS_TOKEN'] || process.env['GMAIL_REFRESH_TOKEN'],
+  );
+
+  if (hasGmailCreds) {
+    console.log('         (最大60秒ポーリング中...)');
+    try {
+      const url = await gmailClient.fetchMinneMagicLink(sentAt, {
+        intervalMs: 3_000,
+        timeoutMs: 60_000,
+      });
+      console.log('        → ログインリンク取得成功');
+      return url;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`\n        Gmail 自動取得失敗: ${msg}`);
+    }
+  }
+
+  console.log(`\n        メール (${email}) を確認してログインリンクをコピーしてください。`);
+  const url = await promptUser('        ログインリンクのURL を貼り付けてください:\n        > ');
+  if (!url) throw new Error('ログインリンクURL が入力されませんでした');
+  return url;
+}
+
+// ---- スプレッドシートリポジトリの生成 ----
+
+function createOrderRepository(): SpreadsheetOrderRepository {
+  const spreadsheetId = process.env['GOOGLE_SHEETS_SPREADSHEET_ID'];
+  if (!spreadsheetId) throw new Error('GOOGLE_SHEETS_SPREADSHEET_ID が設定されていません');
+
+  const serviceAccountBase64 = process.env['GOOGLE_SERVICE_ACCOUNT_BASE64'];
+  let serviceAccountKey: { client_email: string; private_key: string } | undefined;
+  if (serviceAccountBase64) {
+    const json = JSON.parse(
+      Buffer.from(serviceAccountBase64, 'base64').toString('utf-8'),
+    ) as Record<string, unknown>;
+    if (typeof json.client_email === 'string' && typeof json.private_key === 'string') {
+      serviceAccountKey = { client_email: json.client_email, private_key: json.private_key };
+    }
+  }
+
+  const sheetsClient = new GoogleSheetsClient({
+    spreadsheetId,
+    sheetName: process.env['GOOGLE_SHEETS_SHEET_NAME'] ?? 'Orders',
+    serviceAccountKey,
+    accessToken: process.env['GOOGLE_SHEETS_ACCESS_TOKEN'],
+    refreshToken: process.env['GOOGLE_SHEETS_REFRESH_TOKEN'],
+    clientId: process.env['GOOGLE_CLIENT_ID'],
+    clientSecret: process.env['GOOGLE_CLIENT_SECRET'],
+  });
+
+  return new SpreadsheetOrderRepository(sheetsClient);
+}
+
+// ---- メイン ----
+
+async function main(): Promise<void> {
+  loadEnvFile(resolve(process.cwd(), '.env.local'));
+
+  const email = process.env['MINNE_EMAIL'];
+  if (!email) {
+    console.error('エラー: MINNE_EMAIL が設定されていません');
+    process.exit(1);
+  }
+
+  const orderRepository = createOrderRepository();
+  const orderFactory = new OrderFactory();
+
+  console.log('[batch-fetch] ブラウザを起動しています...');
+  const browser = await chromium.launch({ headless: false });
+  try {
+    const page = await browser.newPage();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const minnePage = new MinnePage(page as any);
+
+    // Step 1: ログインリンクを送信
+    console.log(`\n[Step 1] ログインリンクを送信中 (${email})...`);
+    const sentAt = new Date();
+    await minnePage.sendLoginLink(email);
+
+    // Step 2: Gmail からログインリンクを取得
+    console.log('\n[Step 2] Gmail からログインリンクを自動取得中...');
+    const loginUrl = await fetchLoginUrl(sentAt, email);
+
+    // Step 3: セッション確立
+    console.log('\n[Step 3] ログインリンクを開いてセッションを確立中...');
+    await minnePage.openLoginLink(loginUrl);
+    console.log('        → ログイン完了');
+
+    // Step 4: Gmail の未読 minne 購入通知メールから注文 ID を取得
+    console.log('\n[Step 4] Gmail の未読注文メールから注文 ID を取得中...');
+    const gmailClient = new GoogleGmailClient({
+      accessToken: process.env['GMAIL_ACCESS_TOKEN'],
+      refreshToken: process.env['GMAIL_REFRESH_TOKEN'],
+      clientId: process.env['GOOGLE_CLIENT_ID'],
+      clientSecret: process.env['GOOGLE_CLIENT_SECRET'],
+    });
+
+    const unreadEmails = await gmailClient.fetchUnreadMinneOrderEmails();
+    if (unreadEmails.length === 0) {
+      console.log('        → 未読の購入通知メールはありません');
+      return;
+    }
+    console.log(
+      `        → ${unreadEmails.length} 件の未読メールを検出: ` +
+        unreadEmails.map((e) => e.orderId).join(', '),
+    );
+
+    // Step 5: 未登録の注文だけ処理
+    console.log('\n[Step 5] スプシ未登録の注文を取得・保存中...');
+    const result = { saved: 0, skipped: 0, failed: 0 };
+    const errors: string[] = [];
+
+    for (const email of unreadEmails) {
+      const { orderId, messageId } = email;
+      const orderIdVO = new OrderId(orderId);
+
+      if (await orderRepository.exists(orderIdVO)) {
+        console.log(`  [スキップ] ${orderId} - スプシに登録済み`);
+        await gmailClient.markAsRead(messageId).catch(() => {
+          /* 既読化失敗は無視 */
+        });
+        result.skipped++;
+        continue;
+      }
+
+      try {
+        // minne から注文詳細を取得
+        const fetched = await minnePage.fetchOrderData(orderId);
+
+        // Order ドメインオブジェクトに変換
+        const order = orderFactory.createFromPlatformData({
+          orderId: fetched.orderId,
+          platform: Platform.Minne,
+          buyerName: fetched.buyerName,
+          buyerPostalCode: fetched.buyerPostalCode,
+          buyerPrefecture: fetched.buyerPrefecture,
+          buyerCity: fetched.buyerCity,
+          buyerAddress1: fetched.buyerAddress1,
+          buyerAddress2: fetched.buyerAddress2,
+          buyerPhone: fetched.buyerPhone,
+          productName: fetched.productName,
+          price: fetched.price,
+          orderedAt: fetched.orderedAt,
+        });
+
+        // スプシに保存
+        await orderRepository.save(order);
+
+        // 保存成功 → 既読にマーク
+        await gmailClient.markAsRead(messageId).catch(() => {
+          /* 既読化失敗は無視 */
+        });
+
+        console.log(
+          `  [保存]   ${orderId} - ${fetched.buyerName} /` +
+            ` ${fetched.productName} / ${fetched.buyerPrefecture}`,
+        );
+        result.saved++;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`  [失敗]   ${orderId}: ${msg}`);
+        errors.push(`${orderId}: ${msg}`);
+        result.failed++;
+      }
+    }
+
+    // Step 6: 結果サマリー
+    console.log('\n===== 処理結果 =====');
+    console.log(`  保存:     ${result.saved} 件`);
+    console.log(`  スキップ: ${result.skipped} 件（スプシ登録済み）`);
+    console.log(`  失敗:     ${result.failed} 件`);
+    if (errors.length > 0) {
+      console.log('\n  失敗詳細:');
+      errors.forEach((e) => console.log(`    - ${e}`));
+    }
+    console.log('====================\n');
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error('[batch-fetch] エラーが発生しました:');
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/test-minne-fetch.ts
+++ b/scripts/test-minne-fetch.ts
@@ -1,0 +1,157 @@
+/**
+ * minne 購入者情報取得の動作テストスクリプト
+ *
+ * 実行方法:
+ *   npx tsx scripts/test-minne-fetch.ts <注文ID>
+ *
+ * フロー:
+ *   1. minne ログインページでメールアドレスを入力し「ログインリンクを送信」
+ *   2. Gmail API でログインリンクメールを自動取得（最大60秒ポーリング）
+ *      ※ 取得できなかった場合はターミナルで URL を手動入力
+ *   3. Playwright ブラウザがリンクを開いてセッション確立
+ *   4. 注文詳細ページから購入者情報を取得して表示
+ *
+ * .env.local から以下を自動読み込みします:
+ *   MINNE_EMAIL, GMAIL_ACCESS_TOKEN, GMAIL_REFRESH_TOKEN,
+ *   GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET
+ */
+
+import { chromium } from 'playwright';
+import { createInterface } from 'node:readline';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { MinnePage } from '../src/infrastructure/external/playwright/MinnePage';
+import { GoogleGmailClient } from '../src/infrastructure/external/google/GmailClient';
+
+// .env.local を手動パースして process.env に設定する（Next.js 外での実行用）
+function loadEnvFile(filePath: string): void {
+  if (!existsSync(filePath)) return;
+  const content = readFileSync(filePath, 'utf-8');
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.substring(0, eqIdx).trim();
+    let value = trimmed.substring(eqIdx + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function promptUser(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  loadEnvFile(resolve(process.cwd(), '.env.local'));
+
+  const orderId = process.argv[2];
+  if (!orderId) {
+    console.error('エラー: 注文IDを引数で指定してください');
+    console.error('使用方法: npx tsx scripts/test-minne-fetch.ts <注文ID>');
+    process.exit(1);
+  }
+
+  const email = process.env['MINNE_EMAIL'];
+  if (!email) {
+    console.error('エラー: MINNE_EMAIL が設定されていません');
+    process.exit(1);
+  }
+
+  console.log(`[test-minne-fetch] 注文ID: ${orderId}`);
+  console.log('[test-minne-fetch] ブラウザを起動しています (headless=false)...');
+
+  const browser = await chromium.launch({ headless: false });
+  try {
+    const page = await browser.newPage();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const minnePage = new MinnePage(page as any);
+
+    // Step 1: ログインリンクを送信
+    console.log(`\n[Step 1] ログインリンクを送信中 (${email})...`);
+    const sentAt = new Date();
+    await minnePage.sendLoginLink(email);
+    console.log('        → 送信完了');
+
+    // Step 2: Gmail からログインリンクを自動取得（失敗時は手動入力にフォールバック）
+    const loginUrl = await fetchLoginUrl(sentAt, email);
+
+    // Step 3: Playwright ブラウザでログインリンクを開いてセッション確立
+    console.log('\n[Step 3] ログインリンクを開いてセッションを確立中...');
+    await minnePage.openLoginLink(loginUrl);
+    console.log('        → ログイン完了');
+
+    // Step 4: 注文詳細ページから購入者情報を取得
+    console.log(`\n[Step 4] 注文詳細ページから購入者情報を取得中 (ID: ${orderId})...`);
+    const result = await minnePage.fetchOrderData(orderId);
+
+    console.log('\n===== 取得結果 =====');
+    console.log(JSON.stringify(result, null, 2));
+    console.log('====================\n');
+
+    console.log('[test-minne-fetch] 完了');
+  } finally {
+    await browser.close();
+  }
+}
+
+async function fetchLoginUrl(sentAt: Date, email: string): Promise<string> {
+  const gmailClient = new GoogleGmailClient({
+    accessToken: process.env['GMAIL_ACCESS_TOKEN'],
+    refreshToken: process.env['GMAIL_REFRESH_TOKEN'],
+    clientId: process.env['GOOGLE_CLIENT_ID'],
+    clientSecret: process.env['GOOGLE_CLIENT_SECRET'],
+  });
+
+  const hasGmailCreds = Boolean(
+    process.env['GMAIL_ACCESS_TOKEN'] || process.env['GMAIL_REFRESH_TOKEN'],
+  );
+
+  if (hasGmailCreds) {
+    console.log('\n[Step 2] Gmail からログインリンクを自動取得中...');
+    console.log('         (最大60秒ポーリング。メールが届くまでお待ちください)');
+    try {
+      const url = await gmailClient.fetchMinneMagicLink(sentAt, {
+        intervalMs: 3_000,
+        timeoutMs: 60_000,
+      });
+      console.log('        → ログインリンク取得成功');
+      return url;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`\n[Step 2] Gmail 自動取得に失敗しました: ${msg}`);
+      console.warn('         手動入力にフォールバックします。');
+    }
+  } else {
+    console.log('\n[Step 2] Gmail 認証情報が未設定のため手動入力モードで続行します。');
+    console.log(
+      `         (.env.local に GMAIL_REFRESH_TOKEN / GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET を設定すると自動化できます)`,
+    );
+  }
+
+  // フォールバック: 手動入力
+  console.log(`\n        メール (${email}) を確認してログインリンクをコピーしてください。`);
+  const url = await promptUser('        ログインリンクのURL を貼り付けてください:\n        > ');
+  if (!url) throw new Error('ログインリンクURL が入力されませんでした');
+  return url;
+}
+
+main().catch((error: unknown) => {
+  console.error('[test-minne-fetch] エラーが発生しました:');
+  console.error(error);
+  process.exit(1);
+});

--- a/src/infrastructure/adapters/platform/MinneAdapter.ts
+++ b/src/infrastructure/adapters/platform/MinneAdapter.ts
@@ -2,14 +2,13 @@ import { OrderFetcher, PlatformOrderData } from '@/domain/ports/OrderFetcher';
 import { OrderId } from '@/domain/valueObjects/OrderId';
 import { Platform } from '@/domain/valueObjects/Platform';
 import {
-  MinneCredentials,
+  MinneFetchResult,
   MinnePage,
-  MinnePageLike,
-  MinneScrapedOrderData,
+  MinnePlaywrightPageLike,
 } from '@/infrastructure/external/playwright/MinnePage';
 
 export interface MinneBrowserLike {
-  newPage(): Promise<MinnePageLike>;
+  newPage(): Promise<MinnePlaywrightPageLike>;
   close(): Promise<void>;
 }
 
@@ -19,26 +18,33 @@ export interface MinneBrowserFactory {
 
 interface MinneAdapterDependencies {
   readonly browserFactory: MinneBrowserFactory;
-  readonly credentials: MinneCredentials;
+  readonly email: string;
+  /**
+   * ログインリンク URL を提供するコールバック。
+   * - テスト時: ターミナルでユーザーが入力
+   * - Phase 5: GmailAdapter を使って自動取得予定
+   */
+  readonly getLoginUrl: (email: string) => Promise<string>;
 }
 
 export class MinneAdapter implements OrderFetcher {
   constructor(private readonly dependencies: MinneAdapterDependencies) {}
 
-  async fetch(orderId: OrderId, platform: Platform): Promise<PlatformOrderData> {
-    if (!platform.equals(Platform.Minne)) {
-      throw new Error(`MinneAdapter は minne 専用です: ${platform.toString()}`);
-    }
-
+  async fetch(orderId: OrderId, _platform: Platform): Promise<PlatformOrderData> {
     const browser = await this.dependencies.browserFactory.launch();
     try {
       const page = await browser.newPage();
       const minnePage = new MinnePage(page);
-      const scraped = await minnePage.fetchOrder(orderId, this.dependencies.credentials);
-      return this.toPlatformOrderData(orderId, scraped);
+
+      await minnePage.sendLoginLink(this.dependencies.email);
+      const loginUrl = await this.dependencies.getLoginUrl(this.dependencies.email);
+      await minnePage.openLoginLink(loginUrl);
+      const result = await minnePage.fetchOrderData(orderId.toString());
+
+      return this.toPlatformOrderData(result);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`minne 注文取得に失敗しました: ${message}`, { cause: error });
+      throw new Error(`minne注文情報の取得に失敗しました: ${message}`, { cause: error });
     } finally {
       await browser.close().catch((closeError) => {
         console.warn('[MinneAdapter] browser.close に失敗しました', closeError);
@@ -46,19 +52,20 @@ export class MinneAdapter implements OrderFetcher {
     }
   }
 
-  private toPlatformOrderData(orderId: OrderId, scraped: MinneScrapedOrderData): PlatformOrderData {
+  private toPlatformOrderData(result: MinneFetchResult): PlatformOrderData {
     return {
-      orderId: orderId.toString(),
+      orderId: result.orderId,
       platform: Platform.Minne,
-      buyerName: scraped.buyerName,
-      buyerPostalCode: scraped.buyerPostalCode,
-      buyerPrefecture: scraped.buyerPrefecture,
-      buyerCity: scraped.buyerCity,
-      buyerAddress1: scraped.buyerAddress1,
-      buyerAddress2: scraped.buyerAddress2,
-      buyerPhone: scraped.buyerPhone,
-      productName: scraped.productName,
-      orderedAt: scraped.orderedAt,
+      buyerName: result.buyerName,
+      buyerPostalCode: result.buyerPostalCode,
+      buyerPrefecture: result.buyerPrefecture,
+      buyerCity: result.buyerCity,
+      buyerAddress1: result.buyerAddress1,
+      buyerAddress2: result.buyerAddress2,
+      buyerPhone: result.buyerPhone,
+      productName: result.productName,
+      price: result.price,
+      orderedAt: result.orderedAt,
     };
   }
 }

--- a/src/infrastructure/adapters/platform/__tests__/MinneAdapter.test.ts
+++ b/src/infrastructure/adapters/platform/__tests__/MinneAdapter.test.ts
@@ -5,8 +5,60 @@ import { OrderId } from '@/domain/valueObjects/OrderId';
 import { Platform } from '@/domain/valueObjects/Platform';
 import { MinneAdapter, MinneBrowserFactory } from '../MinneAdapter';
 
-function createTextContentMock(values: Record<string, string>) {
-  return vi.fn(async (selector: string) => values[selector] ?? null);
+/**
+ * 実際の minne 注文詳細ページ配送先ブロックの innerText 形式
+ * （<br> が \n に変換されたもの）
+ */
+const DELIVERY_BLOCK_TEXT =
+  '〒150-0001\n東京都渋谷区神宮前1-2-3\n山田 花子\nTEL：09012345678';
+
+/**
+ * セレクタごとのモック値マップ。
+ * resolvedSelectors に含まれるものは "DOM に存在する" とみなす。
+ */
+function createPageMock() {
+  const resolvedSelectors = new Set([
+    // sendLoginLink で使うセレクタ
+    'input[type="email"]',
+    'button:has-text("ログインリンクを送信")',
+    // fetchOrderData で使うセレクタ
+    'h3:has-text("配送先情報") + .p-content-section__body > div',
+    '.p-order-product__name a',
+    'dt:has-text("注文日") + dd',
+  ]);
+
+  const waitForSelector = vi.fn(async (selector: string) => {
+    if (!resolvedSelectors.has(selector)) {
+      throw new Error(`Selector not found in mock: ${selector}`);
+    }
+    return null;
+  });
+
+  // innerText は <br> → \n 変換済みのテキストを返す（配送先ブロック）
+  const innerText = vi.fn(async (selector: string) => {
+    if (selector === 'h3:has-text("配送先情報") + .p-content-section__body > div') {
+      return DELIVERY_BLOCK_TEXT;
+    }
+    return '';
+  });
+
+  const textContent = vi.fn(async (selector: string) => {
+    const values: Record<string, string> = {
+      '.p-order-product__name a': 'ハンドメイドピアス',
+      'dt:has-text("注文日") + dd': '2026/02/22',
+    };
+    return values[selector] ?? null;
+  });
+
+  return {
+    goto: vi.fn(async () => undefined),
+    fill: vi.fn(async () => undefined),
+    click: vi.fn(async () => undefined),
+    textContent,
+    innerText,
+    waitForSelector,
+    waitForLoadState: vi.fn(async () => undefined),
+  };
 }
 
 describe('MinneAdapter', () => {
@@ -15,89 +67,66 @@ describe('MinneAdapter', () => {
   });
 
   it('OrderFetcher を実装し、minne 注文情報を PlatformOrderData として返す', async () => {
-    const fill = vi.fn(async () => undefined);
-    const click = vi.fn(async () => undefined);
-    const goto = vi.fn(async () => undefined);
+    const page = createPageMock();
     const close = vi.fn(async () => undefined);
-    const textContent = createTextContentMock({
-      '.buyer-name': '山田 花子',
-      '.shipping-postal-code': '150-0001',
-      '.shipping-prefecture': '東京都',
-      '.shipping-city': '渋谷区',
-      '.shipping-address-line1': '神宮前1-2-3',
-      '.shipping-address-line2': 'サンプルビル101',
-      '.shipping-phone': '090-1234-5678',
-      '.product-name': 'ハンドメイドピアス',
-      '.ordered-at': '2026-02-22T12:34:56.000Z',
-    });
-
     const browserFactory: MinneBrowserFactory = {
       launch: vi.fn(async () => ({
-        newPage: vi.fn(async () => ({
-          goto,
-          fill,
-          click,
-          textContent,
-        })),
+        newPage: vi.fn(async () => page),
         close,
       })),
     };
+    const getLoginUrl = vi.fn(
+      async () => 'https://minne.com/users/sign_in/magic_link/token123',
+    );
 
     const adapter = new MinneAdapter({
       browserFactory,
-      credentials: {
-        email: 'minne@example.com',
-        password: 'secret',
-      },
+      email: 'minne@example.com',
+      getLoginUrl,
     });
     const fetcher: OrderFetcher = adapter;
 
     const data = await fetcher.fetch(new OrderId('MN-00001'), Platform.Minne);
-    expect(data).toEqual({
-      orderId: 'MN-00001',
-      platform: Platform.Minne,
-      buyerName: '山田 花子',
-      buyerPostalCode: '1500001',
-      buyerPrefecture: '東京都',
-      buyerCity: '渋谷区',
-      buyerAddress1: '神宮前1-2-3',
-      buyerAddress2: 'サンプルビル101',
-      buyerPhone: '09012345678',
-      productName: 'ハンドメイドピアス',
-      orderedAt: new Date('2026-02-22T12:34:56.000Z'),
-    });
-    expect(goto).toHaveBeenCalledWith('https://minne.com/signin');
-    expect(goto).toHaveBeenCalledWith('https://minne.com/orders/MN-00001');
-    expect(fill).toHaveBeenCalledWith('#email', 'minne@example.com');
-    expect(fill).toHaveBeenCalledWith('#password', 'secret');
-    expect(click).toHaveBeenCalledWith('button[type="submit"]');
+
+    // 購入者情報の検証
+    expect(data.orderId).toBe('MN-00001');
+    expect(data.platform).toBe(Platform.Minne);
+    expect(data.buyerName).toBe('山田 花子');
+    expect(data.buyerPostalCode).toBe('1500001');
+    expect(data.buyerPrefecture).toBe('東京都');
+    expect(data.buyerCity).toBe('渋谷区');
+    expect(data.buyerAddress1).toBe('神宮前1-2-3');
+    expect(data.buyerAddress2).toBeUndefined();
+    expect(data.buyerPhone).toBe('09012345678');
+    expect(data.productName).toBe('ハンドメイドピアス');
+
+    // ログインフローの確認
+    expect(page.goto).toHaveBeenCalledWith('https://minne.com/users/sign_in');
+    expect(page.fill).toHaveBeenCalledWith('input[type="email"]', 'minne@example.com');
+    expect(page.click).toHaveBeenCalledWith('button:has-text("ログインリンクを送信")');
+    expect(getLoginUrl).toHaveBeenCalledWith('minne@example.com');
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://minne.com/users/sign_in/magic_link/token123',
+    );
+    expect(page.goto).toHaveBeenCalledWith('https://minne.com/account/orders/MN-00001');
+
+    // ブラウザが閉じられることを確認
     expect(close).toHaveBeenCalledTimes(1);
   });
 
   it('OrderFactory.createFromPlatformData で Order に変換できる', async () => {
-    const textContent = createTextContentMock({
-      '.buyer-name': '山田 花子',
-      '.shipping-postal-code': '150-0001',
-      '.shipping-prefecture': '東京都',
-      '.shipping-city': '渋谷区',
-      '.shipping-address-line1': '神宮前1-2-3',
-      '.product-name': 'ハンドメイドピアス',
-      '.ordered-at': '2026-02-22T12:34:56.000Z',
-    });
+    const page = createPageMock();
     const browserFactory: MinneBrowserFactory = {
       launch: vi.fn(async () => ({
-        newPage: vi.fn(async () => ({
-          goto: vi.fn(async () => undefined),
-          fill: vi.fn(async () => undefined),
-          click: vi.fn(async () => undefined),
-          textContent,
-        })),
+        newPage: vi.fn(async () => page),
         close: vi.fn(async () => undefined),
       })),
     };
+
     const adapter = new MinneAdapter({
       browserFactory,
-      credentials: { email: 'minne@example.com', password: 'secret' },
+      email: 'minne@example.com',
+      getLoginUrl: async () => 'https://minne.com/users/sign_in/magic_link/token',
     });
 
     const raw = await adapter.fetch(new OrderId('MN-00002'), Platform.Minne);
@@ -109,21 +138,26 @@ describe('MinneAdapter', () => {
     expect(order.product.name).toBe('ハンドメイドピアス');
   });
 
-  it('minne 以外の platform 指定はエラー', async () => {
+  it('エラー発生時もブラウザが必ず close される', async () => {
+    const close = vi.fn(async () => undefined);
     const browserFactory: MinneBrowserFactory = {
       launch: vi.fn(async () => ({
-        newPage: vi.fn(),
-        close: vi.fn(async () => undefined),
+        newPage: vi.fn(async () => {
+          throw new Error('ページ生成に失敗');
+        }),
+        close,
       })),
     };
+
     const adapter = new MinneAdapter({
       browserFactory,
-      credentials: { email: 'minne@example.com', password: 'secret' },
+      email: 'minne@example.com',
+      getLoginUrl: async () => 'https://minne.com/users/sign_in/magic_link/token',
     });
 
-    await expect(adapter.fetch(new OrderId('CR-00001'), Platform.Creema)).rejects.toThrow(
-      'MinneAdapter は minne 専用です: creema',
+    await expect(adapter.fetch(new OrderId('MN-00001'), Platform.Minne)).rejects.toThrow(
+      'minne注文情報の取得に失敗しました',
     );
-    expect(browserFactory.launch).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/infrastructure/external/google/GmailClient.ts
+++ b/src/infrastructure/external/google/GmailClient.ts
@@ -238,3 +238,311 @@ export class GmailClient {
     return Buffer.from(normalized + padding, 'base64').toString('utf8');
   }
 }
+
+// ---------------------------------------------------------------------------
+// GoogleGmailClient — OAuth2 リフレッシュトークン対応 / minne マジックリンク対応
+// ---------------------------------------------------------------------------
+
+const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
+
+export interface GoogleGmailClientConfig {
+  readonly accessToken?: string;
+  readonly refreshToken?: string;
+  readonly clientId?: string;
+  readonly clientSecret?: string;
+  readonly baseUrl?: string;
+  readonly tokenUrl?: string;
+}
+
+export interface MagicLinkPollOptions {
+  readonly intervalMs?: number;
+  readonly timeoutMs?: number;
+}
+
+/** minne の購入通知メールから抽出した注文情報 */
+export interface UnreadOrderEmail {
+  /** Gmail メッセージ ID（既読化に使用） */
+  readonly messageId: string;
+  /** minne の注文 ID */
+  readonly orderId: string;
+}
+
+interface GoogleGmailListResponse {
+  messages?: Array<{ id: string }>;
+}
+
+interface GoogleGmailMessageDetail {
+  internalDate?: string;
+  payload: GoogleGmailPayload;
+}
+
+interface GoogleGmailPayload {
+  mimeType?: string;
+  body?: { data?: string };
+  parts?: GoogleGmailPayload[];
+}
+
+export class GoogleGmailClient {
+  private readonly fetcher: FetchLike;
+  private accessToken: string | undefined;
+  private accessTokenExpiresAt: number | undefined;
+
+  constructor(
+    private readonly config: GoogleGmailClientConfig,
+    fetcher: FetchLike = fetch,
+  ) {
+    this.fetcher = fetcher;
+    this.accessToken = config.accessToken;
+  }
+
+  /**
+   * minne のログインリンクメールを Gmail から取得してマジックリンク URL を返す。
+   * sentAfter 以降に届いたメールのみを対象とし、見つかるまでポーリングする。
+   */
+  async fetchMinneMagicLink(sentAfter: Date, options: MagicLinkPollOptions = {}): Promise<string> {
+    const intervalMs = options.intervalMs ?? 3_000;
+    const timeoutMs = options.timeoutMs ?? 60_000;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const link = await this.tryFetchMagicLink(sentAfter);
+      if (link) return link;
+
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await sleepMs(Math.min(intervalMs, remaining));
+    }
+
+    throw new ExternalServiceError(
+      `minne ログインリンクメールの取得がタイムアウトしました (${timeoutMs / 1000}秒)。` +
+        '手動でメールのURLを貼り付けてください。',
+    );
+  }
+
+  /**
+   * Gmail の未読 minne 購入通知メール（from: order@minne.com）から注文IDを一括取得する。
+   */
+  async fetchUnreadMinneOrderEmails(): Promise<UnreadOrderEmail[]> {
+    const query = 'is:unread from:order@minne.com';
+    const url = `${this.getBaseUrl()}/messages?q=${encodeURIComponent(query)}&maxResults=50`;
+    const data = await this.googleGet<GoogleGmailListResponse>(url);
+    if (!data.messages || data.messages.length === 0) return [];
+
+    const results: UnreadOrderEmail[] = [];
+    for (const msg of data.messages) {
+      const body = await this.getMessagePlainText(msg.id);
+      const orderId = this.extractMinneOrderId(body);
+      if (orderId) {
+        results.push({ messageId: msg.id, orderId });
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Gmail メッセージを既読にマークする（処理済み注文の再取得を防ぐ）。
+   */
+  async markAsRead(messageId: string): Promise<void> {
+    const url = `${this.getBaseUrl()}/messages/${messageId}/modify`;
+    await this.googlePostJson(url, { removeLabelIds: ['UNREAD'] });
+  }
+
+  private extractMinneOrderId(body: string): string | null {
+    // URL 例: https://minne.com/account/orders/53509952?utm_...
+    const urlMatch = body.match(/minne\.com\/account\/orders\/(\d+)/);
+    if (urlMatch?.[1]) return urlMatch[1];
+
+    // フォールバック: 本文の「注文ID： 53509952」形式
+    const textMatch = body.match(/注文ID\s*[：:]\s*(\d+)/);
+    return textMatch?.[1] ?? null;
+  }
+
+  private async tryFetchMagicLink(sentAfter: Date): Promise<string | null> {
+    try {
+      const query = 'from:login@minne.com subject:ログインリンクを発行しました';
+      const messageId = await this.findLatestMessageAfter(query, sentAfter);
+      if (!messageId) return null;
+
+      const body = await this.getMessagePlainText(messageId);
+      return this.extractMagicLink(body);
+    } catch {
+      return null;
+    }
+  }
+
+  private async findLatestMessageAfter(query: string, sentAfter: Date): Promise<string | null> {
+    const url = `${this.getBaseUrl()}/messages?q=${encodeURIComponent(query)}&maxResults=5`;
+    const data = await this.googleGet<GoogleGmailListResponse>(url);
+    if (!data.messages || data.messages.length === 0) return null;
+
+    for (const msg of data.messages) {
+      const detail = await this.getMessageDetail(msg.id);
+      const internalDate = parseInt(detail.internalDate ?? '0', 10);
+      if (internalDate >= sentAfter.getTime()) {
+        return msg.id;
+      }
+    }
+    return null;
+  }
+
+  private async getMessageDetail(messageId: string): Promise<GoogleGmailMessageDetail> {
+    const url = `${this.getBaseUrl()}/messages/${messageId}?format=full`;
+    return this.googleGet<GoogleGmailMessageDetail>(url);
+  }
+
+  private async getMessagePlainText(messageId: string): Promise<string> {
+    const detail = await this.getMessageDetail(messageId);
+    return this.extractTextFromPayload(detail.payload);
+  }
+
+  private extractTextFromPayload(payload: GoogleGmailPayload): string {
+    if (payload.mimeType === 'text/plain' && payload.body?.data) {
+      return decodeBase64Url(payload.body.data);
+    }
+    if (payload.parts) {
+      for (const part of payload.parts) {
+        if (part.mimeType === 'text/plain' && part.body?.data) {
+          return decodeBase64Url(part.body.data);
+        }
+      }
+      for (const part of payload.parts) {
+        const text = this.extractTextFromPayload(part);
+        if (text) return text;
+      }
+    }
+    return '';
+  }
+
+  private extractMagicLink(body: string): string | null {
+    const match = body.match(/https:\/\/minne\.com\/users\/sign_in\/magic_link\S*/);
+    return match ? match[0] : null;
+  }
+
+  private async googleGet<T>(url: string): Promise<T> {
+    const response = await this.requestWithAuth(url, { method: 'GET' });
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        throw new AuthenticationError(`Gmail API 認証エラー: ${response.status}`);
+      }
+      throw new ExternalServiceError(
+        `Gmail API エラー: ${response.status} ${response.statusText}`,
+      );
+    }
+    return response.json() as Promise<T>;
+  }
+
+  private async googlePostJson(url: string, body: unknown): Promise<void> {
+    const response = await this.requestWithAuth(url, {
+      method: 'POST',
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new ExternalServiceError(
+        `Gmail API POST エラー: ${response.status} ${response.statusText}`,
+      );
+    }
+  }
+
+  private async requestWithAuth(
+    url: string,
+    options: { method: 'GET' | 'POST'; contentType?: string; body?: BodyInit },
+  ): Promise<Response> {
+    const headers: Record<string, string> = await this.createAuthHeaders();
+    if (options.contentType) headers['Content-Type'] = options.contentType;
+
+    const res = await this.fetcher(url, { method: options.method, headers, body: options.body });
+
+    if (!res.ok && (res.status === 401 || res.status === 403)) {
+      await this.refreshAccessToken();
+      const retryHeaders: Record<string, string> = await this.createAuthHeaders();
+      if (options.contentType) retryHeaders['Content-Type'] = options.contentType;
+      return this.fetcher(url, { method: options.method, headers: retryHeaders, body: options.body });
+    }
+
+    return res;
+  }
+
+  private async createAuthHeaders(): Promise<Record<string, string>> {
+    const token = await this.getGoogleAccessToken();
+    return { Authorization: `Bearer ${token}` };
+  }
+
+  private async getGoogleAccessToken(): Promise<string> {
+    if (
+      this.accessToken &&
+      (this.accessTokenExpiresAt === undefined || Date.now() < this.accessTokenExpiresAt - 30_000)
+    ) {
+      return this.accessToken;
+    }
+
+    if (this.canRefreshToken()) {
+      await this.refreshAccessToken();
+    } else {
+      throw new AuthenticationError(
+        'Gmail API のアクセストークンが設定されていないか期限切れです。' +
+          'GMAIL_ACCESS_TOKEN または GMAIL_REFRESH_TOKEN を設定してください。',
+      );
+    }
+
+    if (!this.accessToken) {
+      throw new AuthenticationError('Gmail API のアクセストークンを取得できませんでした');
+    }
+
+    return this.accessToken;
+  }
+
+  private canRefreshToken(): boolean {
+    return Boolean(this.config.refreshToken && this.config.clientId && this.config.clientSecret);
+  }
+
+  private async refreshAccessToken(): Promise<void> {
+    const { refreshToken, clientId, clientSecret } = this.config;
+    if (!refreshToken || !clientId || !clientSecret) {
+      throw new AuthenticationError('Google OAuth2 リフレッシュトークン設定が不足しています');
+    }
+
+    const response = await this.fetcher(this.getTokenUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new AuthenticationError('Google OAuth2 アクセストークン更新に失敗しました');
+    }
+
+    const payload = (await response.json()) as { access_token?: string; expires_in?: number };
+    if (!payload.access_token) {
+      throw new AuthenticationError('Google OAuth2 トークン更新レスポンスが不正です');
+    }
+
+    this.accessToken = payload.access_token;
+    this.accessTokenExpiresAt =
+      typeof payload.expires_in === 'number'
+        ? Date.now() + payload.expires_in * 1000
+        : undefined;
+  }
+
+  private getBaseUrl(): string {
+    return this.config.baseUrl ?? GMAIL_API_BASE;
+  }
+
+  private getTokenUrl(): string {
+    return this.config.tokenUrl ?? 'https://oauth2.googleapis.com/token';
+  }
+}
+
+function decodeBase64Url(encoded: string): string {
+  const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+  return Buffer.from(base64, 'base64').toString('utf-8');
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/infrastructure/external/playwright/MinnePage.ts
+++ b/src/infrastructure/external/playwright/MinnePage.ts
@@ -1,36 +1,105 @@
-import { OrderId } from '@/domain/valueObjects/OrderId';
+// minne 注文詳細ページから購入者情報を取得する Playwright ラッパー
+//
+// ログイン方式: マジックリンク認証（パスワードなし）
+//   ① sendLoginLink(email)    … メアドを入力して「ログインリンクを送信」ボタンをクリック
+//   ② openLoginLink(url)      … メールから取得したURLをブラウザで開いてセッション確立
+//   ③ fetchOrderData(orderId) … 注文詳細ページに移動して購入者情報を抽出
+//
+// 注文詳細 URL: https://minne.com/account/orders/{orderId}
+//
+// 配送先情報ブロックの HTML 構造:
+//   <h3 class="p-content-section__heading">配送先情報</h3>
+//   <div class="p-content-section__body">
+//     <div>
+//       〒220-0073<br>
+//       神奈川県横浜市西区岡野 1-1-17 ベイシス横濱岡野1階<br>
+//       篠原 有里<br>
+//       TEL：0468617084
+//     </div>
+//   </div>
+// → innerText で取得し、行単位でパースする
 
-const MINNE_LOGIN_URL = 'https://minne.com/signin';
-const MINNE_ORDER_DETAIL_URL = 'https://minne.com/orders';
+const MINNE_LOGIN_URL = 'https://minne.com/users/sign_in';
+const MINNE_ORDER_BASE_URL = 'https://minne.com/account/orders';
+const SHORT_TIMEOUT_MS = 3_000;
 
 const SELECTORS = {
-  email: ['#email', 'input[name="email"]', 'input[type="email"]'] as const,
-  password: ['#password', 'input[name="password"]', 'input[type="password"]'] as const,
-  loginButton: ['button[type="submit"]', 'input[type="submit"]', 'text=ログイン'] as const,
-  buyerName: ['.buyer-name', '[data-testid="buyer-name"]', '#buyer-name'] as const,
-  postalCode: ['.shipping-postal-code', '[data-testid="postal-code"]', '#postal-code'] as const,
-  prefecture: ['.shipping-prefecture', '[data-testid="prefecture"]', '#prefecture'] as const,
-  city: ['.shipping-city', '[data-testid="city"]', '#city'] as const,
-  address1: ['.shipping-address-line1', '[data-testid="address1"]', '#address1'] as const,
-  address2: ['.shipping-address-line2', '[data-testid="address2"]', '#address2'] as const,
-  phone: ['.shipping-phone', '[data-testid="phone"]', '#phone'] as const,
-  productName: ['.product-name', '[data-testid="product-name"]', '#product-name'] as const,
-  orderedAt: ['.ordered-at', '[data-testid="ordered-at"]', '#ordered-at'] as const,
+  // メールアドレス入力欄
+  email: ['input[type="email"]', '#user_email', 'input[name="user[email]"]'] as const,
+  // 「ログインリンクを送信」ボタン
+  sendLoginLinkButton: [
+    'button:has-text("ログインリンクを送信")',
+    'button[type="submit"]:has-text("ログイン")',
+    'button[type="submit"]',
+    'input[type="submit"]',
+  ] as const,
+  // 配送先情報ブロック全体（郵便番号・住所・氏名・電話番号をまとめて取得）
+  deliveryBlock: [
+    'h3:has-text("配送先情報") + .p-content-section__body > div',
+    'h3:has-text("配送先情報") ~ .p-content-section__body > div',
+    '.p-content-section__body > div:first-child',
+  ] as const,
+  // 商品名（確認済み: .p-order-product__name a）
+  productName: [
+    '.p-order-product__name a',
+    '.p-order-product__name',
+    '.item-name a',
+    '.item-name',
+    'dt:has-text("商品名") + dd',
+    'th:has-text("商品名") ~ td',
+    '[data-testid="product-name"]',
+  ] as const,
+  // オプション明細（確認済み: .p-order-product__custom-detail）
+  // 例: "イヤーカフサイズ(金/銀箔)：三角M(金箔) (0円)"
+  productOption: ['.p-order-product__custom-detail'] as const,
+  // 商品金額
+  price: [
+    'dt:has-text("商品金額") + dd',
+    'dt:has-text("合計金額") + dd',
+    'dt:has-text("金額") + dd',
+    'th:has-text("金額") ~ td',
+    '.order-total',
+    '.price',
+    '[data-testid="price"]',
+  ] as const,
+  // 注文日
+  orderedAt: [
+    'dt:has-text("注文日") + dd',
+    'dt:has-text("購入日") + dd',
+    'th:has-text("注文日") ~ td',
+    '.order-date',
+    '.ordered-at',
+    '[data-testid="ordered-at"]',
+    'time',
+  ] as const,
+  // エラーメッセージ
+  error: [
+    '.flash--error',
+    '.flash-message--error',
+    '.alert-danger',
+    '[role="alert"]',
+    '.error-message',
+  ] as const,
 } as const;
 
-export interface MinneCredentials {
-  readonly email: string;
-  readonly password: string;
-}
-
-export interface MinnePageLike {
-  goto(url: string, options?: { timeout?: number }): Promise<void>;
+export interface MinnePlaywrightPageLike {
+  goto(url: string): Promise<void>;
   fill(selector: string, value: string): Promise<void>;
-  click(selector: string, options?: { timeout?: number }): Promise<void>;
+  click(selector: string): Promise<void>;
   textContent(selector: string): Promise<string | null>;
+  // innerText は <br> を \n に変換して返すため配送先ブロックのパースに使用
+  innerText?(selector: string): Promise<string>;
+  waitForSelector?(
+    selector: string,
+    options?: { timeout?: number; state?: 'attached' | 'visible' | 'detached' | 'hidden' },
+  ): Promise<unknown>;
+  waitForLoadState?(state?: 'domcontentloaded' | 'load' | 'networkidle'): Promise<void>;
+  // ページ内 JS 評価（注文一覧から href を一括取得するために使用）
+  evaluate?<T = unknown>(fn: () => T): Promise<T>;
 }
 
-export interface MinneScrapedOrderData {
+export interface MinneFetchResult {
+  readonly orderId: string;
   readonly buyerName: string;
   readonly buyerPostalCode: string;
   readonly buyerPrefecture: string;
@@ -39,116 +108,322 @@ export interface MinneScrapedOrderData {
   readonly buyerAddress2?: string;
   readonly buyerPhone?: string;
   readonly productName: string;
+  readonly price?: number;
   readonly orderedAt: Date;
 }
 
 export class MinnePage {
-  constructor(private readonly page: MinnePageLike) {}
+  constructor(private readonly page: MinnePlaywrightPageLike) {}
 
-  async fetchOrder(
-    orderId: OrderId,
-    credentials: MinneCredentials,
-  ): Promise<MinneScrapedOrderData> {
-    await this.login(credentials);
-    await this.openOrder(orderId);
-    return this.scrapeOrder();
-  }
-
-  private async login(credentials: MinneCredentials): Promise<void> {
+  /**
+   * ① ログインページでメールアドレスを入力し「ログインリンクを送信」ボタンをクリックする。
+   */
+  async sendLoginLink(email: string): Promise<void> {
     await this.page.goto(MINNE_LOGIN_URL);
-
-    const emailFilled = await this.fillFirst([...SELECTORS.email], credentials.email);
-    if (!emailFilled) {
-      throw new Error('minne ログインメール入力欄を検出できませんでした');
-    }
-
-    const passwordFilled = await this.fillFirst([...SELECTORS.password], credentials.password);
-    if (!passwordFilled) {
-      throw new Error('minne ログインパスワード入力欄を検出できませんでした');
-    }
-
-    const clicked = await this.clickFirst([...SELECTORS.loginButton]);
-    if (!clicked) {
-      throw new Error('minne ログインボタンを検出できませんでした');
-    }
+    await this.page.waitForLoadState?.('domcontentloaded');
+    await this.fillFirst(SELECTORS.email, email, 'メールアドレス');
+    await this.clickFirst(SELECTORS.sendLoginLinkButton, 'ログインリンク送信ボタン');
+    await this.page.waitForLoadState?.('domcontentloaded');
+    await this.throwIfErrorDisplayed();
   }
 
-  private async openOrder(orderId: OrderId): Promise<void> {
-    await this.page.goto(`${MINNE_ORDER_DETAIL_URL}/${encodeURIComponent(orderId.toString())}`);
+  /**
+   * ② メールから取得したログインリンク URL をブラウザで開き、セッションを確立する。
+   */
+  async openLoginLink(loginUrl: string): Promise<void> {
+    await this.page.goto(loginUrl);
+    await this.page.waitForLoadState?.('networkidle');
+    await this.throwIfErrorDisplayed();
   }
 
-  private async scrapeOrder(): Promise<MinneScrapedOrderData> {
-    const buyerName = await this.requiredText([...SELECTORS.buyerName], '購入者名');
-    const buyerPostalCode = await this.requiredText([...SELECTORS.postalCode], '郵便番号');
-    const buyerPrefecture = await this.requiredText([...SELECTORS.prefecture], '都道府県');
-    const buyerCity = await this.requiredText([...SELECTORS.city], '市区町村');
-    const buyerAddress1 = await this.requiredText([...SELECTORS.address1], '番地');
-    const buyerAddress2 = await this.optionalText([...SELECTORS.address2]);
-    const buyerPhone = await this.optionalText([...SELECTORS.phone]);
-    const productName = await this.requiredText([...SELECTORS.productName], '商品名');
-    const orderedAtText = await this.requiredText([...SELECTORS.orderedAt], '注文日時');
-    const orderedAt = new Date(orderedAtText);
-    if (Number.isNaN(orderedAt.getTime())) {
-      throw new Error(`注文日時の形式が不正です: ${orderedAtText}`);
+  /**
+   * ③ 注文一覧ページに移動して全注文IDを返す。
+   *    スプシに未登録の注文だけを後続処理で取得するために使用する。
+   */
+  async fetchAllOrderIds(): Promise<string[]> {
+    await this.page.goto(`${MINNE_ORDER_BASE_URL}`);
+    await this.page.waitForLoadState?.('networkidle');
+
+    if (!this.page.evaluate) {
+      throw new Error('fetchAllOrderIds: evaluate が未実装のページオブジェクトです');
     }
+
+    // ページ内の全注文リンクの href を取得
+    const hrefs = await this.page.evaluate(() => {
+      const links = document.querySelectorAll<HTMLAnchorElement>('a[href*="/account/orders/"]');
+      return Array.from(links).map((a) => a.href);
+    });
+
+    // /account/orders/{数字} の形式から ID を抽出（宛名印刷・らくらく等のサブパスは除外）
+    const seen = new Set<string>();
+    for (const href of hrefs) {
+      const match = href.match(/\/account\/orders\/(\d+)(?:\/|$)/);
+      if (match?.[1]) {
+        seen.add(match[1]);
+      }
+    }
+
+    return [...seen];
+  }
+
+  /**
+   * ④ セッション確立後、注文詳細ページに移動して購入者情報を取得する。
+   */
+  async fetchOrderData(orderId: string): Promise<MinneFetchResult> {
+    await this.page.goto(`${MINNE_ORDER_BASE_URL}/${orderId}`);
+    await this.page.waitForLoadState?.('networkidle');
+    await this.throwIfErrorDisplayed();
+    return this.extractOrderData(orderId);
+  }
+
+  private async extractOrderData(orderId: string): Promise<MinneFetchResult> {
+    // 配送先情報ブロックを innerText で取得（<br> → \n 変換）
+    const deliveryText = await this.innerTextFromFirst(SELECTORS.deliveryBlock);
+    if (!deliveryText) {
+      throw new Error(`配送先情報ブロックを取得できませんでした (注文ID: ${orderId})`);
+    }
+
+    const delivery = this.parseDeliveryBlock(deliveryText);
+    const parsedAddress = this.parseAddress(delivery.address);
+
+    const productNameRaw = await this.textFromFirst(SELECTORS.productName);
+    const productOptionRaw = await this.textFromFirst(SELECTORS.productOption);
+    const priceRaw = await this.textFromFirst(SELECTORS.price);
+    const orderedAtRaw = await this.textFromFirst(SELECTORS.orderedAt);
+
+    const productName = this.buildProductName(
+      productNameRaw?.trim() ?? '',
+      productOptionRaw ?? null,
+    );
 
     return {
-      buyerName,
-      buyerPostalCode: buyerPostalCode.replace(/[^\d]/g, ''),
-      buyerPrefecture,
-      buyerCity,
-      buyerAddress1,
-      buyerAddress2: buyerAddress2 || undefined,
-      buyerPhone: buyerPhone?.replace(/[^\d]/g, '') || undefined,
+      orderId,
+      buyerName: delivery.name,
+      buyerPostalCode: delivery.postalCode,
+      buyerPrefecture: parsedAddress.prefecture,
+      buyerCity: parsedAddress.city,
+      buyerAddress1: parsedAddress.street,
+      buyerAddress2: parsedAddress.building,
+      buyerPhone: delivery.phone,
       productName,
-      orderedAt,
+      price: this.parsePrice(priceRaw),
+      orderedAt: this.parseDate(orderedAtRaw),
     };
   }
 
-  private async fillFirst(selectors: string[], value: string): Promise<boolean> {
-    for (const selector of selectors) {
-      try {
-        await this.page.fill(selector, value);
-        return true;
-      } catch {
-        // try next selector
+  /**
+   * 商品名とオプション値を結合して「商品名(オプション値)」形式を返す。
+   *
+   * オプションテキスト例:
+   *   "イヤーカフサイズ(金/銀箔)：三角M(金箔) (0円)"
+   *   → オプション値: "三角M(金箔)"
+   *   → 結果: "商品名(三角M(金箔))"
+   *
+   * オプションが複数ある場合（複数 `.p-order-product__custom-detail`）は
+   * 現状 textFromFirst で最初の1件のみ取得する。
+   * 複数オプションが必要になったら evaluate で全件取得する方式に拡張すること。
+   */
+  private buildProductName(name: string, optionDetailText: string | null): string {
+    if (!optionDetailText) return name;
+
+    const optionValue = this.parseOptionValue(optionDetailText);
+    if (!optionValue) return name;
+
+    return `${name}(${optionValue})`;
+  }
+
+  /**
+   * オプション明細テキストから値部分のみを抽出する。
+   *
+   * 形式: "{オプション名}：{オプション値} ({価格}円)"
+   * → "{オプション値}" を返す
+   */
+  private parseOptionValue(detailText: string): string | undefined {
+    // 全角コロン「：」で分割（ASCII「:」も念のため対応）
+    const colonIdx = detailText.search(/[：:]/);
+    if (colonIdx === -1) return undefined;
+
+    const afterColon = detailText.substring(colonIdx + 1);
+    // 末尾の " (0円)" / " (3500円)" を除去
+    return afterColon.replace(/\s*\(\d+円\)\s*$/, '').trim() || undefined;
+  }
+
+  /**
+   * 配送先ブロックのテキストを行単位でパースする。
+   *
+   * 想定フォーマット（行順）:
+   *   〒220-0073
+   *   神奈川県横浜市西区岡野 1-1-17 ベイシス横濱岡野1階
+   *   篠原 有里
+   *   TEL：0468617084
+   */
+  private parseDeliveryBlock(rawText: string): {
+    postalCode: string;
+    address: string;
+    name: string;
+    phone?: string;
+  } {
+    const lines = rawText
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+
+    // TEL 行を起点に逆算（行順が変わっても対応できるように）
+    const telIdx = lines.findIndex((l) => /^TEL[：:]/i.test(l));
+
+    let phone: string | undefined;
+    let name: string;
+    let address: string;
+    let postalCode: string;
+
+    if (telIdx >= 0) {
+      phone = lines[telIdx].replace(/^TEL[：:]\s*/i, '').trim();
+      name = lines[telIdx - 1] ?? '';
+      address = lines[telIdx - 2] ?? '';
+      postalCode = lines[telIdx - 3] ?? '';
+    } else {
+      // TEL 行がない場合: 末尾から逆算
+      name = lines[lines.length - 1] ?? '';
+      address = lines[lines.length - 2] ?? '';
+      postalCode = lines[lines.length - 3] ?? '';
+    }
+
+    return {
+      postalCode: postalCode.replace(/[〒\s\-ー－]/g, ''),
+      address: address.trim(),
+      name: name.trim(),
+      phone: phone?.replace(/\s+/g, '') || undefined,
+    };
+  }
+
+  // 住所文字列を都道府県 / 市区郡町村 / 番地 / 建物名に分割
+  private parseAddress(raw: string): {
+    prefecture: string;
+    city: string;
+    street: string;
+    building?: string;
+  } {
+    const normalized = raw.trim();
+
+    const prefMatch = normalized.match(/^(東京都|北海道|(?:大阪|京都)府|.{2,3}県)/);
+    if (!prefMatch) {
+      return { prefecture: '', city: '', street: normalized };
+    }
+    const prefecture = prefMatch[1];
+    const afterPref = normalized.substring(prefecture.length).trim();
+
+    const cityMatch = afterPref.match(
+      /^([^\d０-９\n]+?(?:郡[^\s\n]+?(?:町|村)|市[^\s\n]*?区|市|区|町|村))/,
+    );
+    if (!cityMatch) {
+      return { prefecture, city: '', street: afterPref };
+    }
+    const city = cityMatch[1];
+    const afterCity = afterPref.substring(city.length).trim();
+
+    // スペースで番地と建物名を分割（例: "岡野 1-1-17 ベイシス横濱岡野1階"）
+    const spaceIdx = afterCity.search(/\s+/);
+    if (spaceIdx === -1) {
+      return { prefecture, city, street: afterCity };
+    }
+    const street = afterCity.substring(0, spaceIdx).trim();
+    const building = afterCity.substring(spaceIdx).trim() || undefined;
+
+    return { prefecture, city, street, building };
+  }
+
+  private parsePrice(raw: string | null): number | undefined {
+    if (!raw) return undefined;
+    const digits = raw.replace(/[^\d]/g, '');
+    const num = parseInt(digits, 10);
+    return isNaN(num) ? undefined : num;
+  }
+
+  private parseDate(raw: string | null): Date {
+    if (!raw) return new Date();
+    const patterns = [
+      /(\d{4})\/(\d{1,2})\/(\d{1,2})/,
+      /(\d{4})年(\d{1,2})月(\d{1,2})日/,
+      /(\d{4})-(\d{1,2})-(\d{1,2})/,
+    ];
+    for (const pattern of patterns) {
+      const match = raw.match(pattern);
+      if (match) {
+        return new Date(parseInt(match[1]), parseInt(match[2]) - 1, parseInt(match[3]));
       }
     }
-    return false;
+    const parsed = new Date(raw);
+    return isNaN(parsed.getTime()) ? new Date() : parsed;
   }
 
-  private async clickFirst(selectors: string[]): Promise<boolean> {
-    for (const selector of selectors) {
-      try {
-        await this.page.click(selector);
-        return true;
-      } catch {
-        // try next selector
-      }
+  private async throwIfErrorDisplayed(): Promise<void> {
+    const message = await this.textFromFirst(SELECTORS.error);
+    if (message) {
+      throw new Error(`minne画面でエラーを検出しました: ${message}`);
     }
-    return false;
   }
 
-  private async requiredText(selectors: string[], fieldLabel: string): Promise<string> {
-    const value = await this.optionalText(selectors);
-    if (!value) {
-      throw new Error(`minne 注文詳細の${fieldLabel}を取得できませんでした`);
-    }
-    return value;
-  }
-
-  private async optionalText(selectors: string[]): Promise<string | null> {
+  // innerText で取得（<br> → \n）。未対応の場合は textContent にフォールバック
+  private async innerTextFromFirst(selectors: readonly string[]): Promise<string | null> {
     for (const selector of selectors) {
-      try {
-        const text = await this.page.textContent(selector);
-        const normalized = text?.trim();
-        if (normalized) {
-          return normalized;
-        }
-      } catch {
-        // try next selector
+      if (!(await this.selectorExists(selector))) continue;
+      if (this.page.innerText) {
+        const text = (await this.page.innerText(selector)).trim();
+        if (text) return text;
+      } else {
+        const text = (await this.page.textContent(selector))?.trim();
+        if (text) return text;
       }
     }
     return null;
+  }
+
+  private async fillFirst(
+    selectors: readonly string[],
+    value: string,
+    fieldLabel: string,
+  ): Promise<void> {
+    const selector = await this.firstExistingSelector(selectors);
+    if (!selector) {
+      throw new Error(`${fieldLabel} の入力欄が見つかりませんでした`);
+    }
+    await this.page.fill(selector, value);
+  }
+
+  private async clickFirst(selectors: readonly string[], actionLabel: string): Promise<void> {
+    const selector = await this.firstExistingSelector(selectors);
+    if (!selector) {
+      throw new Error(`${actionLabel} の要素が見つかりませんでした`);
+    }
+    await this.page.click(selector);
+  }
+
+  private async textFromFirst(selectors: readonly string[]): Promise<string | null> {
+    for (const selector of selectors) {
+      if (!(await this.selectorExists(selector))) continue;
+      const value = (await this.page.textContent(selector))?.trim();
+      if (value) return value;
+    }
+    return null;
+  }
+
+  private async firstExistingSelector(selectors: readonly string[]): Promise<string | null> {
+    for (const selector of selectors) {
+      if (await this.selectorExists(selector)) return selector;
+    }
+    return null;
+  }
+
+  private async selectorExists(selector: string): Promise<boolean> {
+    if (!this.page.waitForSelector) return false;
+    try {
+      await this.page.waitForSelector(selector, {
+        timeout: SHORT_TIMEOUT_MS,
+        state: 'visible',
+      });
+      return true;
+    } catch {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
- MinnePage: Playwright wrapper for minne magic link login and order data scraping
  - sendLoginLink / openLoginLink / fetchOrderData / fetchAllOrderIds
  - Delivery block parser using TEL line as anchor (handles <br> via innerText)
  - Product option parser for "商品名(オプション値)" format
- MinneAdapter: OrderFetcher port implementation with injectable getLoginUrl callback
- GmailClient: Gmail REST API client with OAuth2 refresh token support
  - fetchMinneMagicLink: polls for magic link email after login request
  - fetchUnreadMinneOrderEmails: extracts order IDs from unread order@minne.com emails
  - markAsRead: marks processed emails as read to prevent reprocessing
- scripts/test-minne-fetch.ts: single-order test harness
- scripts/test-minne-batch-fetch.ts: batch test harness (Gmail -> spreadsheet)
- package.json: add test:minne and test:minne:batch scripts

All implementations verified against live minne website.