### PR TITLE
feat: DB同期ボタンでProductNameMapも同期する

### DIFF
--- a/src/application/usecases/SyncOrdersToDbUseCase.ts
+++ b/src/application/usecases/SyncOrdersToDbUseCase.ts
@@ -3,9 +3,14 @@ import { ShippingLabelRepository } from '@/domain/ports/ShippingLabelRepository'
 import { OrderSyncRepository } from '@/domain/ports/OrderSyncRepository';
 import { ShippingLabel } from '@/domain/entities/ShippingLabel';
 
+export interface ProductNameMapSyncer {
+  syncToDb(): Promise<void>;
+}
+
 export interface SyncResult {
   readonly ordersSynced: number;
   readonly labelsSynced: number;
+  readonly productNameMapSynced: boolean;
   readonly errors: string[];
 }
 
@@ -14,6 +19,7 @@ export class SyncOrdersToDbUseCase {
     private readonly orderRepository: OrderRepository,
     private readonly labelRepository: ShippingLabelRepository<ShippingLabel>,
     private readonly syncRepository: OrderSyncRepository,
+    private readonly productNameMapSyncer?: ProductNameMapSyncer,
   ) {}
 
   async execute(): Promise<SyncResult> {
@@ -38,6 +44,19 @@ export class SyncOrdersToDbUseCase {
       errors.push(...labelResult.errors);
     }
 
-    return { ordersSynced: orderResult.synced, labelsSynced, errors };
+    // ProductNameMap を同期
+    let productNameMapSynced = false;
+    if (this.productNameMapSyncer) {
+      try {
+        await this.productNameMapSyncer.syncToDb();
+        productNameMapSynced = true;
+      } catch (e) {
+        errors.push(
+          `ProductNameMap同期エラー: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    }
+
+    return { ordersSynced: orderResult.synced, labelsSynced, productNameMapSynced, errors };
   }
 }

--- a/src/application/usecases/__tests__/SyncOrdersToDbUseCase.test.ts
+++ b/src/application/usecases/__tests__/SyncOrdersToDbUseCase.test.ts
@@ -106,6 +106,7 @@ describe('SyncOrdersToDbUseCase', () => {
 
     expect(result.ordersSynced).toBe(1);
     expect(result.labelsSynced).toBe(1);
+    expect(result.productNameMapSynced).toBe(false);
     expect(result.errors).toEqual([]);
   });
 
@@ -119,6 +120,7 @@ describe('SyncOrdersToDbUseCase', () => {
 
     expect(result.ordersSynced).toBe(0);
     expect(result.labelsSynced).toBe(0);
+    expect(result.productNameMapSynced).toBe(false);
     expect(result.errors).toEqual([]);
   });
 
@@ -139,5 +141,37 @@ describe('SyncOrdersToDbUseCase', () => {
 
     expect(result.ordersSynced).toBe(0);
     expect(result.errors).toContain('orders upsert failed: DB error');
+  });
+
+  it('ProductNameMap を同期する', async () => {
+    const mockSyncer = { syncToDb: vi.fn().mockResolvedValue(undefined) };
+
+    const useCase = new SyncOrdersToDbUseCase(
+      mockOrderRepository as unknown as OrderRepository,
+      mockLabelRepository as unknown as ShippingLabelRepository<ShippingLabel>,
+      mockSyncRepository as unknown as OrderSyncRepository,
+      mockSyncer,
+    );
+    const result = await useCase.execute();
+
+    expect(mockSyncer.syncToDb).toHaveBeenCalled();
+    expect(result.productNameMapSynced).toBe(true);
+  });
+
+  it('ProductNameMap 同期エラーを集約する', async () => {
+    const mockSyncer = {
+      syncToDb: vi.fn().mockRejectedValue(new Error('sync failed')),
+    };
+
+    const useCase = new SyncOrdersToDbUseCase(
+      mockOrderRepository as unknown as OrderRepository,
+      mockLabelRepository as unknown as ShippingLabelRepository<ShippingLabel>,
+      mockSyncRepository as unknown as OrderSyncRepository,
+      mockSyncer,
+    );
+    const result = await useCase.execute();
+
+    expect(result.productNameMapSynced).toBe(false);
+    expect(result.errors).toContain('ProductNameMap同期エラー: sync failed');
   });
 });

--- a/src/infrastructure/adapters/persistence/DualWriteProductNameResolver.ts
+++ b/src/infrastructure/adapters/persistence/DualWriteProductNameResolver.ts
@@ -23,7 +23,10 @@ export class DualWriteProductNameResolver implements ProductNameResolver {
     return this.spreadsheetResolver.resolve(originalProductName);
   }
 
-  private async syncToDb(): Promise<void> {
+  /**
+   * スプシの ProductNameMap を DB に同期する（外部から明示的に呼べる公開メソッド）。
+   */
+  async syncToDb(): Promise<void> {
     if (!isSupabaseEnabled()) return;
 
     const supabase = getSupabaseClient();

--- a/src/infrastructure/di/container.ts
+++ b/src/infrastructure/di/container.ts
@@ -495,7 +495,12 @@ export function createContainer(
       }
 
       const syncRepository = new SupabaseOrderSyncRepository(supabaseClient);
-      return new SyncOrdersToDbUseCase(orderRepository, shippingLabelRepository, syncRepository);
+      return new SyncOrdersToDbUseCase(
+        orderRepository,
+        shippingLabelRepository,
+        syncRepository,
+        productNameResolver,
+      );
     },
     getRestoreFromDbUseCase: () => {
       if (!supabaseClient) {


### PR DESCRIPTION
## Summary
- DB同期ボタン押下時に `product_name_map` テーブルも同期されるようにした
- `DualWriteProductNameResolver.syncToDb()` を public 化し、`SyncOrdersToDbUseCase` から呼び出し
- `.env.local` のSupabase URL/キーに含まれていた `\n` を修正し、DB同期が正常動作することを確認済み

## Test plan
- [x] `SyncOrdersToDbUseCase` のユニットテスト5件パス（ProductNameMap同期成功/失敗の2件追加）
- [ ] ブラウザでDB同期ボタンを押し、product_name_mapテーブルにデータが入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)